### PR TITLE
fix: SimplifyQQSettingMe on 8.9.23

### DIFF
--- a/app/src/main/java/cc/ioctl/hook/sideswipe/SimplifyQQSettingMe.kt
+++ b/app/src/main/java/cc/ioctl/hook/sideswipe/SimplifyQQSettingMe.kt
@@ -46,6 +46,7 @@ import io.github.qauxv.util.QQVersion.QQ_8_4_1
 import io.github.qauxv.util.QQVersion.QQ_8_6_0
 import io.github.qauxv.util.QQVersion.QQ_8_6_5
 import io.github.qauxv.util.QQVersion.QQ_8_8_11
+import io.github.qauxv.util.QQVersion.QQ_8_9_23
 import io.github.qauxv.util.hostInfo
 import io.github.qauxv.util.requireMinQQVersion
 import xyz.nextalone.base.MultiItemDelayableHook
@@ -154,7 +155,9 @@ object SimplifyQQSettingMe : MultiItemDelayableHook("SimplifyQQSettingMe") {
                         val underSettingsName = if (requireMinQQVersion(QQ_8_6_0)) "l" else "h"
                         param.thisObject.get(underSettingsName, View::class.java) as? LinearLayout
                     }
-                    underSettingsLayout?.forEachIndexed { i, v ->
+                    val correctUSLayout: LinearLayout? =
+                        if (requireMinQQVersion(QQ_8_9_23)) (underSettingsLayout as LinearLayout)[0] as LinearLayout else underSettingsLayout
+                    correctUSLayout?.forEachIndexed { i, v ->
                         val tv = (v as LinearLayout)[1] as TextView
                         val text = tv.text
                         if (stringHit(text.toString()) || i == 3 && activeItems.contains("当前温度")) {

--- a/app/src/main/java/io/github/qauxv/tlb/QQConfigTable.kt
+++ b/app/src/main/java/io/github/qauxv/tlb/QQConfigTable.kt
@@ -60,6 +60,7 @@ import cc.ioctl.hook.sideswipe.SimplifyQQSettingMe
 import io.github.qauxv.bridge.QQMessageFacade
 import io.github.qauxv.util.QQVersion.QQ_8_0_0
 import io.github.qauxv.util.QQVersion.QQ_8_9_18
+import io.github.qauxv.util.QQVersion.QQ_8_9_23
 import xyz.nextalone.hook.ChatWordsCount
 
 class QQConfigTable : ConfigTableInterface {

--- a/app/src/main/java/io/github/qauxv/util/QQVersion.java
+++ b/app/src/main/java/io/github/qauxv/util/QQVersion.java
@@ -90,4 +90,5 @@ public class QQVersion {
     public static final long QQ_8_9_15 = 3408;
     public static final long QQ_8_9_18 = 3466;
     public static final long QQ_8_9_20 = 3524;
+    public static final long QQ_8_9_23 = 3582;
 }


### PR DESCRIPTION
# Title Here
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
叠buff ,但是能用。

## Issues Fixed or Closed by This PR
SimplifyQQSettingMe on 8.9.23

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [ ] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
