### PR TITLE
misc: fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ QAuxiliary 采用滚动更新方式发布新版本，我们总是推荐用户使
 QAuxiliary 将为分 `CI` 和 `推荐的CI` 两个版本
 
 - `CI` 版本为 commit 后自动触发更新，可能包含外围文档或 CI 流程更新，不会编写任何更新文档或说明，
-  具体更新内容可在[Github](https://github.com/cinit/QAuxiliary/commits/master)
+  具体更新内容可在[GitHub](https://github.com/cinit/QAuxiliary/commits/master)
   自行查看，本更新由开源的流程自动编译发布，可能包含严重的功能及行为异常。
 
 - `推荐的CI` 版本为重大功能变更或长期积累更新，发布频率由开发组决定，包含上次`CI`

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="PageTitle_info">关于</string>
     <string name="ModuleEffectiveVersion">模块生效版本</string>
     <string name="announcement">公告</string>
-    <string name="github">Github</string>
+    <string name="github">GitHub</string>
     <string name="BugCheck">故障排查</string>
     <string name="ModuleVersion">模块版本</string>
     <string name="ModuleVersion_tip">更新模块后需要重启目标应用方可生效</string>


### PR DESCRIPTION
# fix GitHub spelling
replace all two `Github` to `GitHub`

## Description
null

## Issues Fixed or Closed by This PR

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
