### PR TITLE
fix: inject module resources maybe problem in some internal Hook Framework

### DIFF
--- a/app/src/main/java/io/github/qauxv/lifecycle/Parasitics.java
+++ b/app/src/main/java/io/github/qauxv/lifecycle/Parasitics.java
@@ -100,11 +100,13 @@ public class Parasitics {
         if (res == null) {
             return;
         }
-        try {
-            res.getString(R.string.res_inject_success);
-            return;
-        } catch (Resources.NotFoundException ignored) {
-        }
+        // FIXME: 去除资源注入成功检测，每次重复注入资源，可以修复一些内置 Hook 框架注入虽然成功但是依然找不到资源 ID 的问题
+        //        复现：梦境框架、应用转生、LSPatch，QQ 版本 8.3.9、8.4.1
+        //        try {
+        //            res.getString(R.string.res_inject_success);
+        //            return;
+        //        } catch (Resources.NotFoundException ignored) {
+        //        }
         try {
             String sModulePath = HookEntry.getModulePath();
             if (sModulePath == null) {
@@ -641,7 +643,7 @@ public class Parasitics {
 
         @Override
         public Application newApplication(ClassLoader cl, String className, Context context)
-            throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+                throws ClassNotFoundException, IllegalAccessException, InstantiationException {
             return mBase.newApplication(cl, className, context);
         }
 
@@ -652,9 +654,9 @@ public class Parasitics {
 
         @Override
         public Activity newActivity(Class<?> clazz, Context context, IBinder token,
-                                    Application application, Intent intent, ActivityInfo info, CharSequence title,
-                                    Activity parent, String id, Object lastNonConfigurationInstance)
-            throws IllegalAccessException, InstantiationException {
+                Application application, Intent intent, ActivityInfo info, CharSequence title,
+                Activity parent, String id, Object lastNonConfigurationInstance)
+                throws IllegalAccessException, InstantiationException {
             return mBase.newActivity(clazz, context, token, application, intent, info, title, parent, id, lastNonConfigurationInstance);
         }
 


### PR DESCRIPTION
# Title Here
修复一个可能的资源注入问题 

## Description
经过我的测试在一些内置 Hook 框架中，判断资源成功注入但是依然找不到资源 ID 导致注入失败，经过测试去除资源注入的判断代码，每次重复注入就能成功，而且这样做并未发现其它可能存在的问题，能够正常工作。

## Issues Fixed or Closed by This PR

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
