### PR TITLE
feat: add new module safe mode

### DIFF
--- a/app/src/main/java/io/github/qauxv/activity/ConfigV2Activity.java
+++ b/app/src/main/java/io/github/qauxv/activity/ConfigV2Activity.java
@@ -30,6 +30,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Environment;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -48,6 +49,7 @@ import cc.ioctl.util.HostInfo;
 import io.github.qauxv.BuildConfig;
 import io.github.qauxv.R;
 import io.github.qauxv.config.ConfigManager;
+import io.github.qauxv.config.SafeModeManager;
 import io.github.qauxv.databinding.MainV2NormalBinding;
 import io.github.qauxv.fragment.AboutFragment;
 import io.github.qauxv.fragment.CheckAbiVariantFragment;
@@ -55,6 +57,7 @@ import io.github.qauxv.fragment.CheckAbiVariantModel;
 import io.github.qauxv.lifecycle.JumpActivityEntryHook;
 import io.github.qauxv.startup.HookEntry;
 import io.github.qauxv.util.SyncUtils;
+import io.github.qauxv.util.Toasts;
 import io.github.qauxv.util.UiThread;
 import io.github.qauxv.util.hookstatus.AbiUtils;
 import io.github.qauxv.util.hookstatus.HookStatus;
@@ -63,6 +66,7 @@ import me.ketal.util.ComponentUtilKt;
 import name.mikanoshi.customiuizer.holidays.HolidayHelper;
 import name.mikanoshi.customiuizer.utils.Helpers;
 import name.mikanoshi.customiuizer.utils.Helpers.Holidays;
+import xyz.nextalone.util.SystemServiceUtils;
 
 public class ConfigV2Activity extends AppCompatTransferActivity {
 
@@ -242,7 +246,22 @@ public class ConfigV2Activity extends AppCompatTransferActivity {
                                 }
                             }
                         })
-                        .setPositiveButton(android.R.string.ok, null).show();
+                        .setPositiveButton(android.R.string.ok, null)
+                        .setNegativeButton("无法进入？", (dialog, which) -> {
+                            new AlertDialog.Builder(this).setTitle("手动启用安全模式")
+                                    .setMessage("如果模块已经激活但无法进入故障排除界面，或在点击进入故障排除后卡死，"
+                                            + "你可以手动在以下位置建立一个空文件来强制启用 QAuxiliary 的安全模式。\n\n" +
+                                            Environment.getExternalStorageDirectory().getAbsolutePath() +
+                                            "/Android/data/包名(例如 QQ 是 com.tencent.mobileqq)/" +
+                                            SafeModeManager.SAFE_MODE_FILE_NAME + "\n\n"
+                                            + "请注意这个位置在 Android 11 及以上的系统是无法直接访问的，"
+                                            + "你可以使用一些支持访问 Android/data 的第三方文件管理器来操作，例如 MT 管理器。")
+                                    .setPositiveButton(android.R.string.ok, null)
+                                    .setNegativeButton("复制文件名", (dialog1, which1) -> {
+                                        SystemServiceUtils.copyToClipboard(this, SafeModeManager.SAFE_MODE_FILE_NAME);
+                                        Toasts.info(this, "复制成功");
+                                    }).show();
+                        }).show();
                 break;
             }
             default: {

--- a/app/src/main/java/io/github/qauxv/config/SafeModeManager.java
+++ b/app/src/main/java/io/github/qauxv/config/SafeModeManager.java
@@ -1,0 +1,91 @@
+/*
+ * QAuxiliary - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2023 QAuxiliary developers
+ * https://github.com/cinit/QAuxiliary
+ *
+ * This software is non-free but opensource software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version and our eula as published
+ * by QAuxiliary contributors.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * and eula along with this software.  If not, see
+ * <https://www.gnu.org/licenses/>
+ * <https://github.com/cinit/QAuxiliary/blob/master/LICENSE.md>.
+ */
+
+package io.github.qauxv.config;
+
+import android.os.Environment;
+import io.github.qauxv.startup.HookEntry;
+import io.github.qauxv.util.HostInfo;
+import io.github.qauxv.util.Log;
+import java.io.File;
+import java.io.IOException;
+
+public class SafeModeManager {
+
+    private static SafeModeManager INSTANCE;
+
+    public static final String SAFE_MODE_FILE_NAME = "qauxv_safe_mode";
+
+    private File mSafeModeEnableFile;
+
+    public static SafeModeManager getManager() {
+        if (INSTANCE == null) {
+            INSTANCE = new SafeModeManager();
+        }
+        INSTANCE.mSafeModeEnableFile = new File(
+                Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/data/" +
+                        HookEntry.sCurrentPackageName + "/" + SAFE_MODE_FILE_NAME
+        );
+        return INSTANCE;
+    }
+
+    private boolean isAvailable() {
+        if (HostInfo.isInModuleProcess()) {
+            Log.w("SafeModeManager only available in host process, ignored");
+            return false;
+        }
+        return true;
+    }
+
+    public boolean isEnabled() {
+        return isAvailable() && mSafeModeEnableFile.exists();
+    }
+
+    public void setEnabled(boolean isEnable) {
+        if (!isAvailable()) {
+            return;
+        }
+        if (isEnable) {
+            try {
+                boolean isCreated = mSafeModeEnableFile.createNewFile();
+                if (!isCreated) {
+                    throw new IOException("Failed to create file: " + mSafeModeEnableFile.getAbsolutePath());
+                }
+            } catch (SecurityException | IOException e) {
+                Log.e("Safe mode enable failed", e);
+            }
+        } else {
+            if (isEnabled()) {
+                try {
+                    boolean isDeleted = mSafeModeEnableFile.delete();
+                    if (!isDeleted) {
+                        throw new IOException("Failed to delete file: " + mSafeModeEnableFile.getAbsolutePath());
+                    }
+                } catch (SecurityException | IOException e) {
+                    Log.e("Safe mode disable failed", e);
+                }
+            } else {
+                Log.w("Safe mode is not enabled, ignored");
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/qauxv/core/MainHook.java
+++ b/app/src/main/java/io/github/qauxv/core/MainHook.java
@@ -28,21 +28,22 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.system.Os;
 import android.system.StructUtsname;
+import cc.ioctl.hook.SettingEntryHook;
+import cc.ioctl.hook.bak.MuteAtAllAndRedPacket;
+import cc.ioctl.hook.chat.GagInfoDisclosure;
 import cc.ioctl.hook.experimental.FileRecvRedirect;
 import cc.ioctl.hook.experimental.ForcePadMode;
-import cc.ioctl.hook.chat.GagInfoDisclosure;
-import cc.ioctl.hook.bak.MuteAtAllAndRedPacket;
+import cc.ioctl.hook.misc.CustomSplash;
+import cc.ioctl.hook.msg.RevokeMsgHook;
 import cc.ioctl.hook.notification.MuteQZoneThumbsUp;
 import cc.ioctl.hook.ui.misc.OptXListViewScrollBar;
-import cc.ioctl.hook.msg.RevokeMsgHook;
-import cc.ioctl.hook.SettingEntryHook;
+import cc.ioctl.hook.ui.title.RemoveCameraButton;
 import cc.ioctl.util.HostInfo;
 import cc.ioctl.util.Reflex;
-import cc.ioctl.hook.misc.CustomSplash;
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
 import io.github.qauxv.config.ConfigItems;
-import io.github.qauxv.config.ConfigManager;
+import io.github.qauxv.config.SafeModeManager;
 import io.github.qauxv.lifecycle.ActProxyMgr;
 import io.github.qauxv.lifecycle.JumpActivityEntryHook;
 import io.github.qauxv.lifecycle.Parasitics;
@@ -53,7 +54,6 @@ import io.github.qauxv.util.Log;
 import io.github.qauxv.util.SyncUtils;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import cc.ioctl.hook.ui.title.RemoveCameraButton;
 import xyz.nextalone.hook.RemoveSuperQQShow;
 
 /*TitleKit:Lcom/tencent/mobileqq/widget/navbar/NavBarCommon*/
@@ -61,8 +61,6 @@ import xyz.nextalone.hook.RemoveSuperQQShow;
 public class MainHook {
 
     private static MainHook SELF;
-
-    public static final String KEY_SAFE_MODE = "safe_mode";
 
     boolean third_stage_inited = false;
 
@@ -102,7 +100,7 @@ public class MainHook {
             Log.w("WSA detected, aggressive resource injection is required to prevent ResourceNotFound crash.");
             // TODO: 2023-1-20 implement aggressive resource injection
         }
-        boolean safeMode = ConfigManager.getDefaultConfig().getBooleanOrDefault(KEY_SAFE_MODE, false);
+        boolean safeMode = SafeModeManager.getManager().isEnabled();
         if (safeMode) {
             LicenseStatus.sDisableCommonHooks = true;
             Log.i("Safe mode enabled, disable hooks");

--- a/app/src/main/java/io/github/qauxv/fragment/SettingsMainFragment.kt
+++ b/app/src/main/java/io/github/qauxv/fragment/SettingsMainFragment.kt
@@ -27,12 +27,7 @@ import android.animation.AnimatorListenerAdapter
 import android.content.Context
 import android.graphics.Rect
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
 import android.view.animation.AlphaAnimation
 import android.widget.FrameLayout
 import androidx.appcompat.app.AlertDialog
@@ -48,19 +43,10 @@ import io.github.qauxv.R
 import io.github.qauxv.bridge.AppRuntimeHelper
 import io.github.qauxv.bridge.ContactUtils
 import io.github.qauxv.config.ConfigManager
-import io.github.qauxv.core.MainHook
+import io.github.qauxv.config.SafeModeManager
 import io.github.qauxv.dsl.FunctionEntryRouter
-import io.github.qauxv.dsl.func.CategoryDescription
-import io.github.qauxv.dsl.func.FragmentDescription
-import io.github.qauxv.dsl.func.IDslFragmentNode
-import io.github.qauxv.dsl.func.IDslItemNode
-import io.github.qauxv.dsl.func.IDslParentNode
-import io.github.qauxv.dsl.func.UiItemAgentDescription
-import io.github.qauxv.dsl.item.CategoryItem
-import io.github.qauxv.dsl.item.DslTMsgListItemInflatable
-import io.github.qauxv.dsl.item.SimpleListItem
-import io.github.qauxv.dsl.item.TMsgListItem
-import io.github.qauxv.dsl.item.UiAgentItem
+import io.github.qauxv.dsl.func.*
+import io.github.qauxv.dsl.item.*
 import io.github.qauxv.util.SyncUtils
 import io.github.qauxv.util.SyncUtils.async
 import io.github.qauxv.util.SyncUtils.runOnUiThread
@@ -211,7 +197,7 @@ class SettingsMainFragment : BaseRootLayoutFragment() {
         if (!mTargetUiAgentNavId.isNullOrEmpty() && !mTargetUiAgentNavigated) {
             navigateToTargetUiAgentItem()
         }
-        val safeMode = ConfigManager.getDefaultConfig().getBooleanOrDefault(MainHook.KEY_SAFE_MODE, false)
+        val safeMode = SafeModeManager.getManager().isEnabled
         subtitle = if (safeMode) {
             "安全模式（停用所有功能）"
         } else {

--- a/app/src/main/java/io/github/qauxv/fragment/TroubleshootFragment.kt
+++ b/app/src/main/java/io/github/qauxv/fragment/TroubleshootFragment.kt
@@ -58,7 +58,7 @@ import io.github.qauxv.activity.SettingsUiFragmentHostActivity.Companion.createS
 import io.github.qauxv.base.ISwitchCellAgent
 import io.github.qauxv.bridge.AppRuntimeHelper.getLongAccountUin
 import io.github.qauxv.config.ConfigManager
-import io.github.qauxv.core.MainHook
+import io.github.qauxv.config.SafeModeManager
 import io.github.qauxv.dsl.item.CategoryItem
 import io.github.qauxv.dsl.item.DslTMsgListItemInflatable
 import io.github.qauxv.dsl.item.TextSwitchItem
@@ -73,7 +73,6 @@ import io.github.qauxv.util.dexkit.DexKitTarget
 import io.github.qauxv.util.dexkit.ordinal
 import io.github.qauxv.util.dexkit.values
 import io.github.qauxv.util.hostInfo
-import xyz.nextalone.util.SystemServiceUtils
 import kotlin.system.exitProcess
 
 
@@ -138,12 +137,12 @@ class TroubleshootFragment : BaseRootLayoutFragment() {
         override val isCheckable = true
         override var isChecked: Boolean
             get() {
-                return ConfigManager.getDefaultConfig().getBooleanOrDefault(MainHook.KEY_SAFE_MODE, false)
+                return SafeModeManager.getManager().isEnabled
             }
             set(value) {
-                val oldValue = ConfigManager.getDefaultConfig().getBooleanOrDefault(MainHook.KEY_SAFE_MODE, false)
+                val oldValue = SafeModeManager.getManager().isEnabled
                 if (value != oldValue) {
-                    ConfigManager.getDefaultConfig().putBoolean(MainHook.KEY_SAFE_MODE, value).apply()
+                    SafeModeManager.getManager().isEnabled = value
                     if (isResumed) {
                         context?.let {
                             Toasts.info(it, "重启应用后生效")

--- a/app/src/main/java/io/github/qauxv/startup/HookEntry.java
+++ b/app/src/main/java/io/github/qauxv/startup/HookEntry.java
@@ -29,10 +29,9 @@ import io.github.qauxv.R;
 import io.github.qauxv.util.hookstatus.HookStatusInit;
 
 /**
- * Xposed entry class DO NOT MODIFY ANY CODE HERE UNLESS NECESSARY. DO NOT INVOKE ANY METHOD THAT MAY GET IN TOUCH WITH
- * KOTLIN HERE. DO NOT TOUCH ANDROIDX OR KOTLIN HERE, WHATEVER DIRECTLY OR INDIRECTLY. THIS CLASS SHOULD ONLY CALL
- * {@code StartupHook.getInstance().doInit()} AND RETURN GRACEFULLY. OTHERWISE SOMETHING MAY HAPPEN BECAUSE OF A
- * NON-STANDARD PLUGIN CLASSLOADER.
+ * Xposed entry class DO NOT MODIFY ANY CODE HERE UNLESS NECESSARY. DO NOT INVOKE ANY METHOD THAT MAY GET IN TOUCH WITH KOTLIN HERE. DO NOT TOUCH ANDROIDX OR
+ * KOTLIN HERE, WHATEVER DIRECTLY OR INDIRECTLY. THIS CLASS SHOULD ONLY CALL {@code StartupHook.getInstance().doInit()} AND RETURN GRACEFULLY. OTHERWISE
+ * SOMETHING MAY HAPPEN BECAUSE OF A NON-STANDARD PLUGIN CLASSLOADER.
  *
  * @author kinit
  */
@@ -50,6 +49,8 @@ public class HookEntry implements IXposedHookLoadPackage, IXposedHookZygoteInit 
     private static IXposedHookZygoteInit.StartupParam sInitZygoteStartupParam = null;
     private static String sModulePath = null;
 
+    public static String sCurrentPackageName = null;
+
     /**
      * *** No kotlin code should be invoked here.*** May cause a crash.
      */
@@ -60,6 +61,7 @@ public class HookEntry implements IXposedHookLoadPackage, IXposedHookZygoteInit 
             return;
         }
         sLoadPackageParam = lpparam;
+        sCurrentPackageName = lpparam.packageName;
         // check LSPosed dex-obfuscation
         Class<?> kXposedBridge = XposedBridge.class;
         if (!"de.robv.android.xposed.XposedBridge".equals(kXposedBridge.getName())) {


### PR DESCRIPTION
# Title Here

添加新的模块安全模式

## Description

之前的安全模式也是通过存储到宿主自身的私有目录 (SharedPreferences/MMKV) 来实现的，一旦模块功能发生错误可能会导致宿主无法启动，甚至不能进入故障排除界面，虽然禁用模块可以解决，但是重新激活模块后**之前错误的配置依然存在**，这种情况在一些**内置 Hook** 或者设备的系统**没有 Root 权限**的情况下**只能清除宿主全部数据**来解决。

新的安全模式采用创建空文件来确定安全模式是否已经开启，空文件的位置创建在宿主在 sdcard 中的 Android/data 私有目录下，在 Android 11 及以上系统可以使用类似 MT 管理器的第三方文件管理器访问这个目录来建立这个文件，这样就可以正常打开宿主并排查相应的错误，避免了需要清除宿主全部数据才能修复的问题。

并且这个方式我也写到模块主界面的故障排除入口对话框上了。

<img width="464" alt="image" src="https://user-images.githubusercontent.com/37344460/221065595-0a355a92-218e-4012-85e0-1f9ed3438ce9.png">

## Issues Fixed or Closed by This PR

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
