### PR TITLE
fix:UnlockLeftSlipLimit on QQ 8.9.33 and 8.9.35

### DIFF
--- a/app/src/main/java/com/hicore/hook/UnlockLeftSlipLimit.java
+++ b/app/src/main/java/com/hicore/hook/UnlockLeftSlipLimit.java
@@ -41,10 +41,13 @@ import java.lang.reflect.Method;
 public class UnlockLeftSlipLimit extends CommonSwitchFunctionHook {
 
     public static final UnlockLeftSlipLimit INSTANCE = new UnlockLeftSlipLimit();
-    public static final String methodName = HostInfo.requireMinQQVersion(QQVersion.QQ_8_8_93) ? "H" : "h";
+    public static final String methodName =
+            !HostInfo.requireMinQQVersion(QQVersion.QQ_8_8_93) ? "h" : HostInfo.requireMinQQVersion(QQVersion.QQ_8_9_33) ? "I" : "H";
+
     private UnlockLeftSlipLimit() {
         super(new DexKitTarget[]{NLeftSwipeReplyHelper_reply.INSTANCE});
     }
+
     @NonNull
     @Override
     public String[] getUiItemLocation() {
@@ -53,7 +56,8 @@ public class UnlockLeftSlipLimit extends CommonSwitchFunctionHook {
 
     @Override
     protected boolean initOnce() throws Exception {
-        Method m = MMethod.FindMethod(DexKit.requireMethodFromCache(NLeftSwipeReplyHelper_reply.INSTANCE).getDeclaringClass(), methodName, boolean.class, new Class[0]);
+        Method m = MMethod.FindMethod(DexKit.requireMethodFromCache(NLeftSwipeReplyHelper_reply.INSTANCE).getDeclaringClass(), methodName, boolean.class,
+                new Class[0]);
         HookUtils.hookBeforeIfEnabled(this, m, param -> param.setResult(true));
         return true;
     }

--- a/app/src/main/java/io/github/qauxv/util/QQVersion.java
+++ b/app/src/main/java/io/github/qauxv/util/QQVersion.java
@@ -88,4 +88,6 @@ public class QQVersion {
     public static final long QQ_8_9_25 = 3640;
     public static final long QQ_8_9_28 = 3698;
     public static final long QQ_8_9_28_2 = 3700;
+
+    public static final long QQ_8_9_33 = 3772;
 }


### PR DESCRIPTION
# [Title Here](fix:UnlockLeftSlipLimit on QQ 8.9.33 and 8.9.35)
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
方法名H->I
<!--- Describe your changes in detail here. -->

## Issues Fixed or Closed by This PR

## Check List

- [1] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [1] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
