### PR TITLE
fix: anti-revoke gray tip not showing for a not-received message

### DIFF
--- a/app/src/main/java/cc/ioctl/hook/msg/RevokeMsgHook.java
+++ b/app/src/main/java/cc/ioctl/hook/msg/RevokeMsgHook.java
@@ -23,7 +23,6 @@ package cc.ioctl.hook.msg;
 
 import static de.robv.android.xposed.XposedHelpers.callMethod;
 import static de.robv.android.xposed.XposedHelpers.setObjectField;
-import static io.github.qauxv.util.Initiator._C2CMessageProcessor;
 import static io.github.qauxv.util.Initiator._QQMessageFacade;
 
 import android.app.Activity;
@@ -230,9 +229,10 @@ public class RevokeMsgHook extends CommonConfigFunctionHook {
             throw new IllegalStateException("onRevokeMsg, istroop=" + istroop);
         }
 
-        if (Reflex.isCallingFrom(_C2CMessageProcessor().getName())) {
-            return;
-        }
+        //下方代码导致没收到的消息不显示撤回灰字提示(没收到)
+        //if (Reflex.isCallingFrom(_C2CMessageProcessor().getName())) {
+        //    return;
+        //}
 
         if (!isKeepSelfMsgEnabled() && selfUin.equals(revokerUin)) {
             return;


### PR DESCRIPTION
# 修复防撤回功能开启后未收到的消息不显示灰字提示

## 不能保证不产生其他问题，都怪咕咕华（

## Issues Fixed or Closed by This PR

## Check List

- [ ] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [ ] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
