### PR TITLE
fix: AutoSendOriginalPhoto for QQ 8.9.33+; fix: anti-revoke gray tip not showing for a not-received message

### DIFF
--- a/app/src/main/java/cc/ioctl/hook/msg/RevokeMsgHook.java
+++ b/app/src/main/java/cc/ioctl/hook/msg/RevokeMsgHook.java
@@ -23,7 +23,6 @@ package cc.ioctl.hook.msg;
 
 import static de.robv.android.xposed.XposedHelpers.callMethod;
 import static de.robv.android.xposed.XposedHelpers.setObjectField;
-import static io.github.qauxv.util.Initiator._C2CMessageProcessor;
 import static io.github.qauxv.util.Initiator._QQMessageFacade;
 
 import android.app.Activity;
@@ -230,9 +229,10 @@ public class RevokeMsgHook extends CommonConfigFunctionHook {
             throw new IllegalStateException("onRevokeMsg, istroop=" + istroop);
         }
 
-        if (Reflex.isCallingFrom(_C2CMessageProcessor().getName())) {
-            return;
-        }
+        //下方代码导致没收到的消息不显示撤回灰字提示(没收到)
+        //if (Reflex.isCallingFrom(_C2CMessageProcessor().getName())) {
+        //    return;
+        //}
 
         if (!isKeepSelfMsgEnabled() && selfUin.equals(revokerUin)) {
             return;

--- a/app/src/main/java/xyz/nextalone/hook/AutoSendOriginalPhoto.kt
+++ b/app/src/main/java/xyz/nextalone/hook/AutoSendOriginalPhoto.kt
@@ -48,6 +48,7 @@ object AutoSendOriginalPhoto : CommonSwitchFunctionHook(SyncUtils.PROC_MAIN or S
 
     override fun initOnce() = throwOrTrue {
         val method = when {
+            requireMinQQVersion(QQVersion.QQ_8_9_33) -> "d0"
             requireMinQQVersion(QQVersion.QQ_8_9_18) -> "c0"
             requireMinQQVersion(QQVersion.QQ_8_9_13) -> "d0"
             requireMinQQVersion(QQVersion.QQ_8_9_2) -> "e0"


### PR DESCRIPTION
# fix: AutoSendOriginalPhoto for QQ 8.9.33+; fix: anti-revoke gray tip not showing for a not-received message
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->

## Issues Fixed or Closed by This PR
https://github.com/cinit/QAuxiliary/issues/370
## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
