### PR TITLE
fix: issue #487, MessagingStyle通知的回复功能在Wear OS上失效

### DIFF
--- a/app/src/main/java/moe/zapic/hook/MessagingStyleNotification.kt
+++ b/app/src/main/java/moe/zapic/hook/MessagingStyleNotification.kt
@@ -492,7 +492,7 @@ object MessagingStyleNotification : CommonSwitchFunctionHook(SyncUtils.PROC_ANY)
                     if (uinType != -1) {
                         param.result = null
                         val uin = intent.getStringExtra("TO_UIN") ?:  return
-                        val result = RemoteInput.getResultsFromIntent(intent)?.getString("KEY_REPLY")?: return
+                        val result = RemoteInput.getResultsFromIntent(intent)?.getCharSequence("KEY_REPLY").toString()
                         val selfUin = AppRuntimeHelper.getAccount()
                         // send message
                         ChatActivityFacade.sendMessage(


### PR DESCRIPTION
# Title Here

fix: issue #487, MessagingStyle通知的回复功能在Wear OS上失效

## Description

具体问题见 issue #487 
主要问题出在 logcat 那段日志

## Issues Fixed or Closed by This PR

#487 

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
