### PR TITLE
fix: add description for navbar simplify

### DIFF
--- a/app/src/main/java/cc/ioctl/hook/sideswipe/SimplifyQQSettingMe.kt
+++ b/app/src/main/java/cc/ioctl/hook/sideswipe/SimplifyQQSettingMe.kt
@@ -69,6 +69,7 @@ object SimplifyQQSettingMe : MultiItemDelayableHook("SimplifyQQSettingMe") {
     const val MidContentName = "SimplifyQQSettingMe::MidContentName"
 
     override val preferenceTitle: String = "侧滑栏精简"
+    override val description: String = "可能需要重启 QQ 后生效"
     override val allItems = setOf<String>()
     override val uiItemLocation = FunctionEntryRouter.Locations.Simplify.SLIDING_UI
     override val isAvailable = requireMinQQVersion(QQ_8_4_1)


### PR DESCRIPTION
Test needed.

In my situation, it only works after restart, but it seems that there are some users who get this function to work without restart, so I wrote a tips instead of directly setting require restart to true.