### PR TITLE
feat: multi-user support for TGStickerProvider

### DIFF
--- a/app/src/main/java/cc/microblock/hook/DumpTelegramStickers.kt
+++ b/app/src/main/java/cc/microblock/hook/DumpTelegramStickers.kt
@@ -67,7 +67,7 @@ fun listDir(directoryPath: String): List<FileInfo> {
 val executor = Executors.newFixedThreadPool(2)
 val allowedExtensions = listOf(".png", ".jpg", ".jpeg", ".gif", ".webp");
 
-var baseDir = "/storage/emulated/0/Android/media/com.tencent.mobileqq/TGStickersExported/";
+var baseDir = "/storage/self/primary/Android/media/com.tencent.mobileqq/TGStickersExported/";
 class LocalDocumentEmoticonProvider : ExtraEmoticonProvider() {
     class Panel(val path: String, val id: String) : ExtraEmoticonPanel() {
         private var emoticons: List<ExtraEmoticon> = listOf();
@@ -272,7 +272,7 @@ object DumpTelegramStickers : CommonConfigFunctionHook() {
             addView(
                 AppCompatTextView(ctx).apply {
                     setText("关于插件：需配合 MicroBlock 的 Telegram 表情包同步插件使用\n" +
-                        "你也可以自行在 /storage/emulated/0/Android/media/com.tencent.mobileqq/TGStickersExported/v1/ 下创建包含表情包图片文件的文件夹（支持 png,jpg,webp,gif）。")
+                        "你也可以自行在 /storage/self/primary/Android/media/com.tencent.mobileqq/TGStickersExported/v1/ 下创建包含表情包图片文件的文件夹（支持 png,jpg,webp,gif）。")
                 }
             )
             addView(
@@ -331,9 +331,9 @@ object DumpTelegramStickers : CommonConfigFunctionHook() {
 
         var providers: List<ExtraEmoticonProvider> = listOf(LocalDocumentEmoticonProvider());
 
-        if (!File("/storage/emulated/0/Android/media/com.tencent.mobileqq/TGStickersExported/.nomedia").exists()) {
-            File("/storage/emulated/0/Android/media/com.tencent.mobileqq/TGStickersExported/").mkdirs();
-            File("/storage/emulated/0/Android/media/com.tencent.mobileqq/TGStickersExported/.nomedia").createNewFile();
+        if (!File("/storage/self/primary/Android/media/com.tencent.mobileqq/TGStickersExported/.nomedia").exists()) {
+            File("/storage/self/primary/Android/media/com.tencent.mobileqq/TGStickersExported/").mkdirs();
+            File("/storage/self/primary/Android/media/com.tencent.mobileqq/TGStickersExported/.nomedia").createNewFile();
         }
 
         data class QAEpId (var providerId: String = "",var panelId: String);


### PR DESCRIPTION
# feat: multi-user support for TGStickerProvider
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->

Use `/storage/self/primary` instead of `/storage/emulated/0` to support no-primary user with TGStickerProvider.

## Issues Fixed or Closed by This PR

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
