### PR TITLE
fix: ChatItemShowQQUin for QQ 9.0.8

### DIFF
--- a/app/src/main/java/me/ketal/hook/ChatItemShowQQUin.kt
+++ b/app/src/main/java/me/ketal/hook/ChatItemShowQQUin.kt
@@ -96,6 +96,7 @@ object ChatItemShowQQUin : CommonConfigFunctionHook(), OnBubbleBuilder {
 
     // X2J_APT <- ???Binding(com/tx/x2j/AioSenderBubbleTemplateBinding) <- AIOSenderBubbleTemplate
     private val NAME_TAIL_LAYOUT = when {
+        requireMinQQVersion(QQVersion.QQ_9_0_8) -> "srn"
         requireMinQQVersion(QQVersion.QQ_8_9_93_BETA_13315) -> "so5"
         requireMinQQVersion(QQVersion.QQ_8_9_90) -> "smi"
         requireMinQQVersion(QQVersion.QQ_8_9_88) -> "slx"


### PR DESCRIPTION
# Fix 消息显示 ID 和时间 for QQ 9.0.8
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->
Adapted to the new layoutid.

## Issues Fixed or Closed by This PR
Only for 9.0.8. So, none.

## Check List
- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
