### PR TITLE
fix: DefaultBubbleHook for lower QQ

### DIFF
--- a/app/src/main/java/cc/ioctl/hook/chat/DefaultBubbleHook.java
+++ b/app/src/main/java/cc/ioctl/hook/chat/DefaultBubbleHook.java
@@ -59,8 +59,10 @@ public class DefaultBubbleHook extends CommonSwitchFunctionHook {
 
     @Override
     protected boolean initOnce() throws Exception {
+        final String bubbleClsName = "com.tencent.qqnt.kernel.nativeinterface.VASMsgBubble";
+
         if (requireMinQQVersion(QQVersion.QQ_9_0_15)) {
-            XposedBridge.hookAllConstructors(VASMsgBubble.class, new XC_MethodHook() {
+            XposedBridge.hookAllConstructors(Class.forName(bubbleClsName), new XC_MethodHook() {
                 @Override
                 protected void afterHookedMethod(@NonNull MethodHookParam param) {
                     VASMsgBubble v = (VASMsgBubble) param.thisObject;
@@ -69,8 +71,9 @@ public class DefaultBubbleHook extends CommonSwitchFunctionHook {
                 }
             });
         } else if (QAppUtils.isQQnt()) {
-            HookUtils.hookBeforeIfEnabled(this,VASMsgBubble.class.getDeclaredMethod("getBubbleId"),param -> param.setResult(0));
-            HookUtils.hookBeforeIfEnabled(this,VASMsgBubble.class.getDeclaredMethod("getSubBubbleId"),param -> param.setResult(0));
+            Class<?> bubbleCls = Class.forName(bubbleClsName);
+            HookUtils.hookBeforeIfEnabled(this, bubbleCls.getDeclaredMethod("getBubbleId"), param -> param.setResult(0));
+            HookUtils.hookBeforeIfEnabled(this, bubbleCls.getDeclaredMethod("getSubBubbleId"), param -> param.setResult(0));
         } else {
             updateChmod(true);
             Class<?> kAIOMsgItem = Initiator.load("com.tencent.mobileqq.aio.msg.AIOMsgItem");


### PR DESCRIPTION
# fix DefaultBubbleHook for lower QQ / 修复旧版QQ的聊天强制默认气泡

## Description
用 `Class.forName` 代替 `VASMsgBubble.class` 避免 R8 将 `const-class` 前移从而找不到类

## Issues Fixed or Closed by This PR
#785

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
