### PR TITLE
Change the supported versions of new ChatItemShowQQUin to QQ 8.9.93.13315+

### DIFF
--- a/app/src/main/java/me/ketal/hook/ChatItemShowQQUin.kt
+++ b/app/src/main/java/me/ketal/hook/ChatItemShowQQUin.kt
@@ -106,8 +106,6 @@ object ChatItemShowQQUin : CommonConfigFunctionHook(), OnBubbleBuilder {
 
     // X2J_APT <- ???Binding(com/tx/x2j/AioSenderBubbleTemplateBinding) <- AIOSenderBubbleTemplate
     private val NAME_TAIL_LAYOUT = when {
-        requireMinQQVersion(QQVersion.QQ_9_0_8) -> "srn"
-        requireMinQQVersion(QQVersion.QQ_8_9_93_BETA_13315) -> "so5"
         requireMinQQVersion(QQVersion.QQ_8_9_90) -> "smi"
         requireMinQQVersion(QQVersion.QQ_8_9_88) -> "slx"
         requireMinQQVersion(QQVersion.QQ_8_9_85) -> "sih"
@@ -357,7 +355,7 @@ object ChatItemShowQQUin : CommonConfigFunctionHook(), OnBubbleBuilder {
         val isFlashPicTagNeedShow = FlashPicHook.INSTANCE.isInitializationSuccessful && isFlashPicNt(chatMessage)
         if (!isEnabled && !isFlashPicTagNeedShow) return
 
-        if (requireMinQQVersion(QQVersion.QQ_9_0_15)) {
+        if (requireMinQQVersion(QQVersion.QQ_8_9_93_BETA_13315)) {
             if (!rootView.children.map { it.id }.contains(ID_ADD_LAYOUT)) {
                 val layout = LinearLayout(rootView.context).apply {
                     layoutParams = ConstraintLayout.LayoutParams(


### PR DESCRIPTION
# Change the supported versions of new ChatItemShowQQUin to QQ 8.9.93.13315+
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->
Change the supported versions of new ChatItemShowQQUin to QQ 8.9.93.13315+ to supprt QQ 8.9.93~9.0.0 and improve display effect on QQ 9.0.15-
Tested on QQ 8.9.93.13315, 8.9.93, 9.0.0, 9.0.8&9.0.9
## Issues Fixed or Closed by This PR

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
