### PR TITLE
feat: Remove open contact tip (Need sign)

### DIFF
--- a/app/src/main/java/io/github/moonleeeaf/hook/AddEssenceViewerToGroupSettingsHook.java
+++ b/app/src/main/java/io/github/moonleeeaf/hook/AddEssenceViewerToGroupSettingsHook.java
@@ -58,13 +58,13 @@ public class AddEssenceViewerToGroupSettingsHook extends CommonSwitchFunctionHoo
     @NonNull
     @Override
     public String getName() {
-        return "在群设置页添加精华消息入口";
+        return "群设置页添加精华消息入口";
     }
   
     @NonNull
     @Override
     public String getDescription() {
-        return "本功能仅针对 TIM 用户\n如果打开后的列表为空，可能是由于 p_skey 不在内置浏览器的 Cookie 内，可以尝试打开群机器人页面，随意点击一个资料卡以解决（即使网页提示错误）\n不保证永久可用";
+        return "供 TIM 用户使用\n\n如果打开后的列表为空，可尝试打开群机器人页面，点击任一机器人资料卡以解决(想办法设置 Cookie p_skey 亦可)";
     }
 
     @NonNull

--- a/app/src/main/java/io/github/moonleeeaf/hook/FxxkGroupChangeNotificationTipsForTIM.kt
+++ b/app/src/main/java/io/github/moonleeeaf/hook/FxxkGroupChangeNotificationTipsForTIM.kt
@@ -37,7 +37,7 @@ object FxxkGroupChangeNotificationTipsForTIM : CommonSwitchFunctionHook(
     arrayOf(PushNotificationManager_judgeAndAddGrayTips)
 ) {
     override val name = "移除群聊灰字“打开消息推送设置”"
-    override val description = "参考 Issue #889，仅适用于 TIM 3.5.1，未经测试";
+    override val description = "仅适用于 TIM 3.5.1";
 
     override val uiItemLocation = FunctionEntryRouter.Locations.Auxiliary.GROUP_CATEGORY
 

--- a/app/src/main/java/io/github/moonleeeaf/hook/FxxkPasteHereForTIM.kt
+++ b/app/src/main/java/io/github/moonleeeaf/hook/FxxkPasteHereForTIM.kt
@@ -43,7 +43,7 @@ object FxxkPasteHereForTIM : CommonSwitchFunctionHook(
 ) {
 
     override val name = "移除聊天输入框“点击粘贴”"
-    override val description = "仅在 TIM 3.5.1 理论推得，未经测试，参考 Issue #890";
+    override val description = "仅在 TIM 3.5.1 测试通过";
     override val uiItemLocation = FunctionEntryRouter.Locations.Auxiliary.MESSAGE_CATEGORY
 
     override fun initOnce(): Boolean {

--- a/app/src/main/java/io/github/moonleeeaf/hook/RemoveTIMOpenContactTip.kt
+++ b/app/src/main/java/io/github/moonleeeaf/hook/RemoveTIMOpenContactTip.kt
@@ -49,7 +49,7 @@ object RemoveTIMOpenContactTip : CommonSwitchFunctionHook() {
         // 最终找到 aejy 方法名 migrateOldOrDefaultContent
         // 目前该字符串搜出的方法最终调用都在这
 
-        HookUtils.hookBeforeIfEnabled(this, Reflex.findMethod(Initiator.loadClass('aejy'), 'migrateOldOrDefaultContent')) {
+        HookUtils.hookBeforeIfEnabled(this, Reflex.findMethod(Initiator.loadClass("aejy"), "migrateOldOrDefaultContent")) {
             it.result = null;
         }
         return true;

--- a/app/src/main/java/io/github/moonleeeaf/hook/RemoveTIMOpenContactTip.kt
+++ b/app/src/main/java/io/github/moonleeeaf/hook/RemoveTIMOpenContactTip.kt
@@ -50,6 +50,7 @@ object RemoveTIMOpenContactTip : CommonSwitchFunctionHook() {
         // 目前该字符串搜出的方法最终调用都在这
 
         HookUtils.hookBeforeIfEnabled(
+            this,
             Reflex.findMethod(
                 Initiator.loadClass('aejy'), 
                 'migrateOldOrDefaultContent'

--- a/app/src/main/java/io/github/moonleeeaf/hook/RemoveTIMOpenContactTip.kt
+++ b/app/src/main/java/io/github/moonleeeaf/hook/RemoveTIMOpenContactTip.kt
@@ -1,0 +1,63 @@
+/*
+ * QAuxiliary - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2023 QAuxiliary developers
+ * https://github.com/cinit/QAuxiliary
+ *
+ * This software is non-free but opensource software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version and our eula as published
+ * by QAuxiliary contributors.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * and eula along with this software.  If not, see
+ * <https://www.gnu.org/licenses/>
+ * <https://github.com/cinit/QAuxiliary/blob/master/LICENSE.md>.
+ */
+
+package io.github.moonleeeaf.hook
+
+import cc.hicore.QApp.QAppUtils
+import cc.ioctl.util.HookUtils
+import cc.ioctl.util.Reflex
+import io.github.qauxv.base.annotation.FunctionHookEntry
+import io.github.qauxv.base.annotation.UiItemAgentEntry
+import io.github.qauxv.dsl.FunctionEntryRouter
+import io.github.qauxv.hook.CommonSwitchFunctionHook
+import io.github.qauxv.util.Initiator
+import io.github.qauxv.util.dexkit.CopyPromptHelper_handlePrompt
+import io.github.qauxv.util.dexkit.DexKit
+import xyz.nextalone.util.get
+import xyz.nextalone.util.set
+
+// 模板: TimRemoveToastTips.kt
+@FunctionHookEntry
+@UiItemAgentEntry
+object RemoveTIMOpenContactTip : CommonSwitchFunctionHook() {
+
+    override val name = "禁止提示打开通讯录"
+    override val description = "未经测试，根据 TIM 3.5.1 代码编写";
+    override val uiItemLocation = FunctionEntryRouter.Locations.Simplify.MAIN_UI_CONTACT
+
+    override fun initOnce(): Boolean {
+        // 字符串ID 7f0f4c88
+        // 最终找到 aejy 方法名 migrateOldOrDefaultContent
+        // 目前该字符串搜出的方法最终调用都在这
+
+        HookUtils.hookBeforeIfEnabled(
+            Reflex.findMethod(
+                Initiator.loadClass('aejy'), 
+                'migrateOldOrDefaultContent'
+            )
+        ) {
+            it.result = null;
+        }
+        return true;
+    }
+
+}

--- a/app/src/main/java/io/github/moonleeeaf/hook/RemoveTIMOpenContactTip.kt
+++ b/app/src/main/java/io/github/moonleeeaf/hook/RemoveTIMOpenContactTip.kt
@@ -49,13 +49,7 @@ object RemoveTIMOpenContactTip : CommonSwitchFunctionHook() {
         // 最终找到 aejy 方法名 migrateOldOrDefaultContent
         // 目前该字符串搜出的方法最终调用都在这
 
-        HookUtils.hookBeforeIfEnabled(
-            this,
-            Reflex.findMethod(
-                Initiator.loadClass('aejy'), 
-                'migrateOldOrDefaultContent'
-            )
-        ) {
+        HookUtils.hookBeforeIfEnabled(this, Reflex.findMethod(Initiator.loadClass('aejy'), 'migrateOldOrDefaultContent')) {
             it.result = null;
         }
         return true;


### PR DESCRIPTION
# 移除“开启联系人”提示
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->

详见 #892 另外本PR包含了对某些功能提示的修改

由于复现时间较长，因此在修改后仍然需要进行测试（一般来说切换到本设备未登录的账号后有概率弹出）

![Screenshot_2024-04-28-12-30-13-933_com miui home](https://github.com/cinit/QAuxiliary/assets/150461955/7de5d1c5-4213-45da-9b77-159ce0413355)


## Issues Fixed or Closed by This PR

#892 

## Check List

- [ ] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance

备注：签名服务器又炸了（代理都没用），劳烦大佬了（
```
error: gpg failed to sign the data:
gpg: Note: database_open 134217901 waiting for lock (held by 5280) ...
gpg: Note: database_open 134217901 waiting for lock (held by 5280) ...
gpg: Note: database_open 134217901 waiting for lock (held by 5280) ...
gpg: Note: database_open 134217901 waiting for lock (held by 5280) ...
gpg: Note: database_open 134217901 waiting for lock (held by 5280) ...
gpg: keydb_search failed: Connection timed out
gpg: skipped "MoonLeeeaf <150461955+MoonLeeeaf@users.noreply.github.com>": Connection timed out
[GNUPG:] INV_SGNR 0 MoonLeeeaf <150461955+MoonLeeeaf@users.noreply.github.com>
[GNUPG:] FAILURE sign 134250628
gpg: signing failed: Connection timed out

fatal: failed to write commit object
```
