### PR TITLE
fix: HideMiniAppPullEntry init failed

### DIFF
--- a/app/src/main/java/cc/ioctl/hook/ui/main/HideMiniAppPullEntry.kt
+++ b/app/src/main/java/cc/ioctl/hook/ui/main/HideMiniAppPullEntry.kt
@@ -179,7 +179,7 @@ object HideMiniAppPullEntry : CommonSwitchFunctionHook(ConfigItems.qn_hide_msg_l
     override fun makePreparationSteps() = arrayOf(mStep)
 
     override val isNeedFind: Boolean
-        get() = initMiniAppObfsName == null || miniOldStyleHeaderNewMethod == null
+        get() = initMiniAppObfsName == null || (Initiator.load("com.tencent.qqnt.chats.view.MiniOldStyleHeaderNew") != null && miniOldStyleHeaderNewMethod == null)
 
     override fun doFind(): Boolean {
         (getCurrentBackend() as DexKitDeobfs).use { dexKitDeobfs ->


### PR DESCRIPTION
# fix: HideMiniAppPullEntry init failed
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->
修复 https://github.com/cinit/QAuxiliary/commit/b7ddb05d3626ef426e0670f6687759600e5f2b28 导致隐藏下拉小程序在低版本上初始化失败的问题

## Issues Fixed or Closed by This PR
#939 

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
