### PR TITLE
fix: UseAioPhotoChoosePanel for QQ 9.0.55

### DIFF
--- a/app/src/main/java/com/xiaoniu/hook/UseAioPhotoChoosePanel.kt
+++ b/app/src/main/java/com/xiaoniu/hook/UseAioPhotoChoosePanel.kt
@@ -29,6 +29,8 @@ import io.github.qauxv.dsl.FunctionEntryRouter
 import io.github.qauxv.hook.CommonSwitchFunctionHook
 import io.github.qauxv.util.QQVersion
 import io.github.qauxv.util.requireMinQQVersion
+import xyz.nextalone.util.clazz
+import xyz.nextalone.util.hookBeforeAllConstructors
 import xyz.nextalone.util.method
 import xyz.nextalone.util.throwOrTrue
 
@@ -43,8 +45,18 @@ object UseAioPhotoChoosePanel : CommonSwitchFunctionHook() {
 
     override val isAvailable = requireMinQQVersion(QQVersion.QQ_9_0_35)
     override fun initOnce() = throwOrTrue {
-        "Lcom/tencent/mobileqq/aio/api/impl/QQTabApiImpl\$b;->isExperiment(Ljava/lang/String;)Z".method.hookBefore {
-            if (it.args[0] == "exp_QQ_aio_photo_choose_B") it.result = false
+        if (requireMinQQVersion(QQVersion.QQ_9_0_55)) {
+            // 改成1002再改回去
+            "Lcom/tencent/mobileqq/aio/shortcurtbar/AIOShortcutBarVM\$c;".clazz!!.hookBeforeAllConstructors {
+                it.args[0] = 1002
+            }
+            "Lcom/tencent/input/base/panelcontainer/h\$l;".clazz!!.hookBeforeAllConstructors {
+                if (it.args[0] == "AIOShortcutBarVM") it.args[1] = 1003
+            }
+        } else {
+            "Lcom/tencent/mobileqq/aio/api/impl/QQTabApiImpl\$b;->isExperiment(Ljava/lang/String;)Z".method.hookBefore {
+                if (it.args[0] == "exp_QQ_aio_photo_choose_B") it.result = false
+            }
         }
     }
 

--- a/app/src/main/java/com/xiaoniu/hook/UseAioPhotoChoosePanel.kt
+++ b/app/src/main/java/com/xiaoniu/hook/UseAioPhotoChoosePanel.kt
@@ -46,12 +46,12 @@ object UseAioPhotoChoosePanel : CommonSwitchFunctionHook() {
     override val isAvailable = requireMinQQVersion(QQVersion.QQ_9_0_35)
     override fun initOnce() = throwOrTrue {
         if (requireMinQQVersion(QQVersion.QQ_9_0_55)) {
-            // 改成1002再改回去
+            // 改成其他数字再改回去
             "Lcom/tencent/mobileqq/aio/shortcurtbar/AIOShortcutBarVM\$c;".clazz!!.hookBeforeAllConstructors {
-                it.args[0] = 1002
+                if (it.args[0] == 1003) it.args[0] = 114514
             }
             "Lcom/tencent/input/base/panelcontainer/h\$l;".clazz!!.hookBeforeAllConstructors {
-                if (it.args[0] == "AIOShortcutBarVM") it.args[1] = 1003
+                if (it.args[0] == "AIOShortcutBarVM" && it.args[1] == 114514) it.args[1] = 1003
             }
         } else {
             "Lcom/tencent/mobileqq/aio/api/impl/QQTabApiImpl\$b;->isExperiment(Ljava/lang/String;)Z".method.hookBefore {


### PR DESCRIPTION
# fix: UseAioPhotoChoosePanel for QQ 9.0.55

## Description
修复9.0.55下还原图片半屏选择面板

## Issues Fixed or Closed by This PR
#977 

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
