### PR TITLE
fix: UseAioPhotoChoosePanel for QQ 9.0.60

### DIFF
--- a/app/src/main/java/com/xiaoniu/hook/UseAioPhotoChoosePanel.kt
+++ b/app/src/main/java/com/xiaoniu/hook/UseAioPhotoChoosePanel.kt
@@ -48,7 +48,11 @@ object UseAioPhotoChoosePanel : CommonSwitchFunctionHook() {
         if (requireMinQQVersion(QQVersion.QQ_9_0_55)) {
             // 改成其他数字再改回去
             "Lcom/tencent/mobileqq/aio/shortcurtbar/AIOShortcutBarVM\$c;".clazz!!.hookBeforeAllConstructors {
-                if (it.args[0] == 1003) it.args[0] = 114514
+                if (it.args[0] is Int) {
+                    if (it.args[0] == 1003) it.args[0] = 114514
+                } else {
+                    if (it.args[1] == 1003) it.args[1] = 114514
+                }
             }
             "Lcom/tencent/input/base/panelcontainer/h\$l;".clazz!!.hookBeforeAllConstructors {
                 if (it.args[0] == "AIOShortcutBarVM" && it.args[1] == 114514) it.args[1] = 1003


### PR DESCRIPTION
# fix: UseAioPhotoChoosePanel for QQ 9.0.60
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
修复9.0.60下还原图片半屏选择面板

## Issues Fixed or Closed by This PR
#977 

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
