### PR TITLE
feat: remove group toast tip for TIM 3.0.0

### DIFF
--- a/app/src/main/java/cc/microblock/hook/TimRemoveToastTips.kt
+++ b/app/src/main/java/cc/microblock/hook/TimRemoveToastTips.kt
@@ -37,9 +37,9 @@ import xyz.nextalone.util.set
 @UiItemAgentEntry
 object TimRemoveToastTips : CommonSwitchFunctionHook() {
     override val name = "移除群聊“修改/设置消息设置”提示"
-    override val description = "本功能仅在 TIM 3.5.1 测试通过，功能可能对其他版本或其他客户端无效\n\n功能基于 Issue #781 和 #667 移植实现";
+    override val description = "仅供 TIM 3.5.1 使用";
 
-    override val uiItemLocation = FunctionEntryRouter.Locations.Auxiliary.MESSAGE_CATEGORY
+    override val uiItemLocation = FunctionEntryRouter.Locations.Auxiliary.GROUP_CATEGORY
 
     override fun initOnce(): Boolean {
         HookUtils.hookBeforeIfEnabled(

--- a/app/src/main/java/io/github/moonleeeaf/hook/FuckGroupToastTips.kt
+++ b/app/src/main/java/io/github/moonleeeaf/hook/FuckGroupToastTips.kt
@@ -1,0 +1,58 @@
+/*
+ * QAuxiliary - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2023 QAuxiliary developers
+ * https://github.com/cinit/QAuxiliary
+ *
+ * This software is non-free but opensource software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version and our eula as published
+ * by QAuxiliary contributors.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * and eula along with this software.  If not, see
+ * <https://www.gnu.org/licenses/>
+ * <https://github.com/cinit/QAuxiliary/blob/master/LICENSE.md>.
+ */
+
+package io.github.moonleeeaf.hook
+
+import cc.hicore.QApp.QAppUtils
+import cc.ioctl.util.HookUtils
+import cc.ioctl.util.Reflex
+import io.github.qauxv.base.annotation.FunctionHookEntry
+import io.github.qauxv.base.annotation.UiItemAgentEntry
+import io.github.qauxv.dsl.FunctionEntryRouter
+import io.github.qauxv.hook.CommonSwitchFunctionHook
+import io.github.qauxv.util.Initiator
+import xyz.nextalone.util.get
+import xyz.nextalone.util.set
+
+@FunctionHookEntry
+@UiItemAgentEntry
+object FuckGroupToastTips : CommonSwitchFunctionHook() {
+    override val name = "移除群聊“修改消息设置”提示"
+    override val description = "仅供 TIM 3.0.0 使用";
+
+    override val uiItemLocation = FunctionEntryRouter.Locations.Auxiliary.GROUP_CATEGORY
+
+    override fun initOnce(): Boolean {
+        // Resource ID： 0x7f0e0189
+        // Lcom/tencent/mobileqq/activity/aio/rebuild/TroopChatPie$39$1;->run()V
+        // 原文本：修改消息设置，实时...
+        HookUtils.hookBeforeIfEnabled(
+            this, Reflex.findMethod(
+                Initiator.loadClass("com.tencent.mobileqq.activity.aio.rebuild.TroopChatPie\$39\$1"),
+                "run")
+        ) {
+            it.result = null;
+        }
+        return true
+    }
+
+}


### PR DESCRIPTION
# 移除群聊“修改消息设置”提示
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->
1. 将原功能位置移动到 辅助功能 - 群聊
2. 添加专门为 TIM 3.0.0 适配的功能，如题

## Issues Fixed or Closed by This PR

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
