### PR TITLE
fix: remove another toast in TimRemoveToastTips.kt

### DIFF
--- a/app/src/main/java/cc/microblock/hook/TimRemoveToastTips.kt
+++ b/app/src/main/java/cc/microblock/hook/TimRemoveToastTips.kt
@@ -71,6 +71,12 @@ object TimRemoveToastTips : CommonSwitchFunctionHook() {
                 Initiator.loadClass("com.tencent.mobileqq.activity.aio.rebuild.TroopChatPie\$39\$1"),
                 "run"
             )
+            // 7f0e018a
+            // 你可以在这里设置...
+            runMethods += Reflex.findMethod(
+                Initiator.loadClass("com.tencent.mobileqq.activity.aio.rebuild.TroopChatPie\$23"),
+                "run"
+            )
         }
 
         runMethods.forEach {


### PR DESCRIPTION
# 功能修补： 在TIM 3.0.0 移除“你可以在这里设置...”
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->

com.tencent.mobileqq.activity.aio.rebuild.TroopChatPie$23

## Issues Fixed or Closed by This PR

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
