### PR TITLE
fix: AutoReceiveOriginalPhoto on QQ 8.9.63+

### DIFF
--- a/app/src/main/java/io/github/qauxv/util/dexkit/DexKitTarget.kt
+++ b/app/src/main/java/io/github/qauxv/util/dexkit/DexKitTarget.kt
@@ -1010,3 +1010,9 @@ data object Hd_GagInfoDisclosure_Method : DexKitTarget.UsingStr() {
     override val declaringClass = "com.tencent.imcore.message"
     override val filter = DexKitFilter.strInClsName("com/tencent/imcore/message/")
 }
+
+data object OriginalPhotoNT_onInitView : DexKitTarget.UsingDexkit() {
+    override val findMethod: Boolean = true
+    override val declaringClass = ""
+    override val filter: dexkitFilter = DexKitFilter.allowAll
+}


### PR DESCRIPTION
# fix: AutoReceiveOriginalPhoto on QQ 8.9.63+
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->
修复 6c60339e6f56dedc11ac1377b6dfe70dfc833dc5 使用的 "com.tencent.qqnt.aio.gallery.part.d" 类在一些版本上不正确的问题

## Issues Fixed or Closed by This PR

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
