### PR TITLE
fix: SimplifyQQSettingMe (bottom) on QQ 9.0.85+

### DIFF
--- a/app/src/main/java/io/github/qauxv/tlb/QQConfigTable.kt
+++ b/app/src/main/java/io/github/qauxv/tlb/QQConfigTable.kt
@@ -66,6 +66,8 @@ import io.github.qauxv.util.QQVersion.QQ_8_9_90
 import io.github.qauxv.util.QQVersion.QQ_9_0_0
 import io.github.qauxv.util.QQVersion.QQ_9_0_20
 import io.github.qauxv.util.QQVersion.QQ_9_0_35
+import io.github.qauxv.util.QQVersion.QQ_9_0_85
+import io.github.qauxv.util.QQVersion.QQ_9_0_90
 import me.ketal.hook.SortAtPanel
 import xyz.nextalone.hook.ChatWordsCount
 
@@ -129,6 +131,8 @@ class QQConfigTable : ConfigTableInterface {
             QQ_9_0_0 to "f0",
             QQ_9_0_20 to "e0",
             QQ_9_0_35 to "g0",
+            QQ_9_0_85 to "h0",
+            QQ_9_0_90 to "f0",
         ),
 
         SortAtPanel.sessionInfoTroopUin to mapOf(

--- a/app/src/main/java/io/github/qauxv/util/QQVersion.java
+++ b/app/src/main/java/io/github/qauxv/util/QQVersion.java
@@ -128,4 +128,7 @@ public class QQVersion {
     public static final long QQ_9_0_73 = 6722;
     public static final long QQ_9_0_75 = 6786;
     public static final long QQ_9_0_80 = 6896;
+    public static final long QQ_9_0_81 = 6922;
+    public static final long QQ_9_0_85 = 7068;
+    public static final long QQ_9_0_90 = 7196;
 }


### PR DESCRIPTION
# fix: SimplifyQQSettingMe (bottom) on QQ 9.0.85+
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->
修复 QQ 9.0.85+ 侧滑栏精简的底部部分坏掉的问题

## Issues Fixed or Closed by This PR

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
