### PR TITLE
feat: DisableUtfControlCharacterInNickname

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -22,6 +22,7 @@
 -keep class io.github.moonleeeaf.** { *; }
 -keep class io.github.fusumayuki.** { *; }
 -keep class awoo.linwenxuan04.** { *; }
+-keep class wang.allenyou.** { *; }
 
 -keepclasseswithmembernames class * {
     native <methods>;

--- a/app/src/main/java/wang/allenyou/hook/DisableUtfControlCharacterInNicknameHook.kt
+++ b/app/src/main/java/wang/allenyou/hook/DisableUtfControlCharacterInNicknameHook.kt
@@ -1,0 +1,90 @@
+/*
+ * QAuxiliary - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2024 QAuxiliary developers
+ * https://github.com/cinit/QAuxiliary
+ *
+ * This software is an opensource software: you can redistribute it
+ * and/or modify it under the terms of the General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version as published
+ * by QAuxiliary contributors.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the General Public License for more details.
+ *
+ * You should have received a copy of the General Public License
+ * along with this software.
+ * If not, see
+ * <https://github.com/cinit/QAuxiliary/blob/master/LICENSE.md>.
+ */
+
+package wang.allenyou.hook
+
+import android.annotation.SuppressLint
+import android.widget.TextView
+import cc.ioctl.util.hookBeforeIfEnabled
+import io.github.qauxv.base.annotation.FunctionHookEntry
+import io.github.qauxv.base.annotation.UiItemAgentEntry
+import io.github.qauxv.dsl.FunctionEntryRouter
+import io.github.qauxv.hook.CommonSwitchFunctionHook
+import io.github.qauxv.util.Initiator
+import io.github.qauxv.util.Log
+import io.github.qauxv.util.QQVersion
+import io.github.qauxv.util.requireMinQQVersion
+import io.github.qauxv.util.xpcompat.XC_MethodHook
+
+@FunctionHookEntry
+@UiItemAgentEntry
+object DisableUtfControlCharacterInNicknameHook : CommonSwitchFunctionHook() {
+
+    override val name = "过滤聊天中的 UTF-8 特殊字符"
+
+    override val description = "将聊天中出现的特殊字符替换为空格"
+
+    override val uiItemLocation: Array<String> = FunctionEntryRouter.Locations.Simplify.CHAT_OTHER
+
+    override val isAvailable: Boolean get() = requireMinQQVersion(QQVersion.QQ_9_0_20)
+
+    @SuppressLint("BidiSpoofing")
+    private const val BLACKLIST = "‭‮‪‫‎⁦⁧‏"
+
+    override fun initOnce(): Boolean {
+        val textViewClass = Initiator.loadClass("android.widget.TextView")
+        val onPreDrawMethod = textViewClass.getDeclaredMethod("onPreDraw")
+        val wrappedTextViewClass = Initiator.loadClass("android.widget.WrappedTextView")
+        val setWrappedTextMethod = wrappedTextViewClass.getDeclaredMethod("setText", CharSequence::class.java, Initiator.loadClass("android.widget.TextView${'$'}BufferType"))
+        val modifyHook = fun(hookParam: XC_MethodHook.MethodHookParam){
+            if (hookParam.args.isEmpty()) {
+                return
+            }
+            if (hookParam.args[0] !is CharSequence) {
+                return
+            }
+            Log.d("${hookParam.args[0]} [[Allenyou-Debug]]")
+            if (BLACKLIST.map { ch -> (hookParam.args[0] as String).contains(ch)}.isEmpty()) {
+                return
+            }
+            hookParam.args[0] = filterControlCharacter(hookParam.args[0] as CharSequence)
+        }
+        hookBeforeIfEnabled(setWrappedTextMethod, modifyHook)
+        hookBeforeIfEnabled(onPreDrawMethod) {
+            if (it.thisObject !is TextView) {
+                return@hookBeforeIfEnabled
+            }
+            val str = (it.thisObject as TextView).text.toString()
+            if (BLACKLIST.map { ch -> str.contains(ch)}.isEmpty()) {
+                return@hookBeforeIfEnabled
+            }
+            (it.thisObject as TextView).text = filterControlCharacter(str)
+        }
+        return true
+    }
+
+    private fun filterControlCharacter(str: CharSequence): CharSequence {
+        var ret = str.toString()
+        BLACKLIST.forEach { ret = ret.replace(it, ' ') }
+        return ret
+    }
+}


### PR DESCRIPTION
# 标题 / Title Here

添加了将 RTLO、LTRO 等 UTF 控制字符替换为空格的功能

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description

添加了将 RTLO、LTRO 等 UTF 控制字符替换为空格的功能。

实现方法为 Hook `TextView` 的 `onPreDraw()` 方法，判断是否有黑名单内字符，如有则将其替换为空格。

预期实现为导致一次重绘，可能有一定性能下降，实际测试符合预期，未有较明显性能下降。

目前已知的问题为回复消息时，显示的被回复内容无法被 Hook 捕捉替换，怀疑为该处采用的 `FasterTextView` 并未继承自 `TextView` 导致。

<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR

添加了将 RTLO、LTRO 等 UTF 控制字符替换为空格的功能。

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [ ] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
