### PR TITLE
feat:remove audio transition.

### DIFF
--- a/app/src/main/java/io/github/leafmoes/RemoveAudioTransition.kt
+++ b/app/src/main/java/io/github/leafmoes/RemoveAudioTransition.kt
@@ -1,0 +1,53 @@
+/*
+ * QAuxiliary - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2024 QAuxiliary developers
+ * https://github.com/cinit/QAuxiliary
+ *
+ * This software is an opensource software: you can redistribute it
+ * and/or modify it under the terms of the General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version as published
+ * by QAuxiliary contributors.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the General Public License for more details.
+ *
+ * You should have received a copy of the General Public License
+ * along with this software.
+ * If not, see
+ * <https://github.com/cinit/QAuxiliary/blob/master/LICENSE.md>.
+ */
+
+package io.github.leafmoes
+
+import android.content.Context
+import com.github.kyuubiran.ezxhelper.utils.findMethod
+import com.github.kyuubiran.ezxhelper.utils.hookReplace
+import io.github.qauxv.base.annotation.FunctionHookEntry
+import io.github.qauxv.base.annotation.UiItemAgentEntry
+import io.github.qauxv.dsl.FunctionEntryRouter
+import io.github.qauxv.hook.CommonSwitchFunctionHook
+import io.github.qauxv.util.Initiator
+import xyz.nextalone.util.throwOrTrue
+
+
+@FunctionHookEntry
+@UiItemAgentEntry
+object RemoveAudioTransition : CommonSwitchFunctionHook("removeAudioTransition") {
+    override val name: String get() = "移除语音面板多余过渡动画"
+    override val description: String get() = "QQ语音面板左右滑动的时候因为这个动画导致UI重影\n故写此功能移除这个莫名其妙的动画"
+    override val uiItemLocation: Array<String> get() = FunctionEntryRouter.Locations.Simplify.CHAT_OTHER
+
+    override fun initOnce()= throwOrTrue {
+        Initiator.loadClass("com.tencent.mobileqq.activity.aio.audiopanel.AudioTransitionAnimManager")
+            .findMethod {
+                val paramsTypes = parameterTypes
+                parameterCount == 4
+                    && paramsTypes[0] == Int::class.javaPrimitiveType
+                    && paramsTypes[1] == String::class.java
+                    && paramsTypes[2] == Context::class.java
+            }.hookReplace {  }
+    }
+}


### PR DESCRIPTION
# 标题 / Title Here
移除语音面板多余过渡动画

## 描述 / Description

QQ语音面板左右滑动的时候因为这个动画导致UI重影
故写此功能移除这个莫名其妙的动画

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
