### PR TITLE
feat: MiniAppDirectJump supports user self-configuration

### DIFF
--- a/app/src/main/java/top/xunflash/hook/MiniAppDirectJump.kt
+++ b/app/src/main/java/top/xunflash/hook/MiniAppDirectJump.kt
@@ -339,7 +339,7 @@ object MiniAppDirectJump : CommonConfigFunctionHook(targets = arrayOf(CArkAppIte
                         continue
                     }
                 }
-                //if (foundValidApp) break
+                if (foundValidApp) break
             } catch (e: Exception) {
                 continue
             }


### PR DESCRIPTION
# MiniAppDirectJump 小程序/分享卡片跳转APP 支持用户自行配置包名＆正则表达式

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description

1. 小程序/分享卡片跳转APP 支持用户自行配置包名＆正则表达式
2. 新增知乎&小红书&酷安跳转支持

<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
