### PR TITLE
feat: FuckOpenContactsActivity on TIM NT

### DIFF
--- a/app/src/main/java/io/github/moonleeeaf/hook/FuckOpenContactsActivity.java
+++ b/app/src/main/java/io/github/moonleeeaf/hook/FuckOpenContactsActivity.java
@@ -50,8 +50,7 @@ import kotlin.collections.ArraysKt;
 @FunctionHookEntry
 @UiItemAgentEntry
 public class FuckOpenContactsActivity extends CommonSwitchFunctionHook {
-    private Class<?> clz = Initiator.loadClass('com.tencent.mobileqq.activity.phone.PhoneMatchActivity');
-  
+
     @NonNull
     @Override
     public String getName() {
@@ -73,12 +72,12 @@ public class FuckOpenContactsActivity extends CommonSwitchFunctionHook {
     @Override
     public boolean isAvailable() {
         // 不知道怎么判定, 就先看看有没有这个类罢
-        return !(clz == null);
+        return (Initiator.loadClass('com.tencent.mobileqq.activity.phone.PhoneMatchActivity') != null);
     }
 
     @Override
     public boolean initOnce() throws Exception {
-        Method _onCreate =  clz.getDeclaredMethod('onCreate', Bundle.class);
+        Method _onCreate =  Initiator.loadClass('com.tencent.mobileqq.activity.phone.PhoneMatchActivity').getDeclaredMethod('onCreate', Bundle.class);
 
         HookUtils.hookAfterIfEnabled(this, _onCreate, (param) -> {
             Activity self = (Activity) param.thisObject;

--- a/app/src/main/java/io/github/moonleeeaf/hook/FuckOpenContactsActivity.java
+++ b/app/src/main/java/io/github/moonleeeaf/hook/FuckOpenContactsActivity.java
@@ -88,4 +88,4 @@ public class FuckOpenContactsActivity extends CommonSwitchFunctionHook {
         return true;
     }
 
-              }
+}

--- a/app/src/main/java/io/github/moonleeeaf/hook/FuckOpenContactsActivity.java
+++ b/app/src/main/java/io/github/moonleeeaf/hook/FuckOpenContactsActivity.java
@@ -1,0 +1,91 @@
+package io.github.moonleeeaf.hook;
+
+/*
+ * QAuxiliary - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2022 qwq233@qwq2333.top
+ * https://github.com/cinit/QAuxiliary
+ *
+ * This software is non-free but opensource software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version and our eula as published
+ * by QAuxiliary contributors.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * and eula along with this software.  If not, see
+ * <https://www.gnu.org/licenses/>
+ * <https://github.com/cinit/QAuxiliary/blob/master/LICENSE.md>.
+ */
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.Toast;
+import android.os.Bundle;
+import androidx.annotation.NonNull;
+import cc.ioctl.util.HookUtils;
+import cc.ioctl.util.HostInfo;
+import io.github.qauxv.base.annotation.FunctionHookEntry;
+import io.github.qauxv.base.annotation.UiItemAgentEntry;
+import io.github.qauxv.dsl.FunctionEntryRouter;
+import io.github.qauxv.hook.CommonSwitchFunctionHook;
+import io.github.qauxv.util.Initiator;
+import io.github.qauxv.util.dexkit.ChatSettingForTroop_InitUI_TIM;
+import io.github.qauxv.util.dexkit.DexKit;
+import io.github.qauxv.util.dexkit.DexKitTarget;
+import io.github.qauxv.util.dexkit.FormItem_TIM;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import kotlin.collections.ArraysKt;
+
+@FunctionHookEntry
+@UiItemAgentEntry
+public class FuckOpenContactsActivity extends CommonSwitchFunctionHook {
+    private Class<?> clz = Initiator.loadClass('com.tencent.mobileqq.activity.phone.PhoneMatchActivity');
+  
+    @NonNull
+    @Override
+    public String getName() {
+        return "去你妈的打开通讯录";
+    }
+
+    @NonNull
+    @Override
+    public String getDescription() {
+        return "理论支持任意NTQQ, 仅在 TIM NT 4.0.98 测试通过";
+    }
+
+    @NonNull
+    @Override
+    public String[] getUiItemLocation() {
+        return FunctionEntryRouter.Locations.Simplify.MAIN_UI_CONTACT;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        // 不知道怎么判定, 就先看看有没有这个类罢
+        return !(clz == null);
+    }
+
+    @Override
+    public boolean initOnce() throws Exception {
+        Method _onCreate =  clz.getDeclaredMethod('onCreate', Bundle.class);
+
+        HookUtils.hookAfterIfEnabled(this, _onCreate, (param) -> {
+            Activity self = (Activity) param.thisObject;
+            // Hook点太多太复杂 就这样简单粗暴罢(x
+            self.finish();
+        });
+        return true;
+    }
+
+              }


### PR DESCRIPTION
# 标题 / Title Here

去你妈的打开通讯录
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description

直接 finish 如下Activity
![Screenshot_20250120-173817_TIM](https://github.com/user-attachments/assets/97ac5ca5-4ecb-41c9-8291-2cb4a1a6b2df)

<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List

由于目前我仍无法编译此项目, 因此有可能会多次提交以修复一些语法错误 :(

若通过 请直接合并提交()

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [ ] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [ ] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)

我无法理解
```
e: file:///home/runner/work/QAuxiliary/QAuxiliary/app/build/generated/ksp/debug/kotlin/io/github/qauxv/gen/AnnotatedFunctionHookEntryList.kt:473:30 Unresolved reference 'INSTANCE'.
e: file:///home/runner/work/QAuxiliary/QAuxiliary/app/build/generated/ksp/debug/kotlin/io/github/qauxv/gen/AnnotatedUiItemAgentEntryList.kt:484:30 Unresolved reference 'INSTANCE'.
```