### PR TITLE
fix: ChatInputHint on TIM_NT 4.0.98

### DIFF
--- a/app/src/main/java/xyz/nextalone/hook/ChatInputHint.kt
+++ b/app/src/main/java/xyz/nextalone/hook/ChatInputHint.kt
@@ -41,11 +41,13 @@ import io.github.qauxv.hook.CommonConfigFunctionHook
 import io.github.qauxv.ui.CommonContextWrapper
 import io.github.qauxv.util.Initiator
 import io.github.qauxv.util.QQVersion
+import io.github.qauxv.util.TIMVersion
 import io.github.qauxv.util.Toasts
 import io.github.qauxv.util.dexkit.AIO_InputRootInit_QQNT
 import io.github.qauxv.util.dexkit.DexKit
 import io.github.qauxv.util.dexkit.NBaseChatPie_init
 import io.github.qauxv.util.requireMinQQVersion
+import io.github.qauxv.util.requireMinTimVersion
 import kotlinx.coroutines.flow.MutableStateFlow
 import xyz.nextalone.util.findHostView
 import xyz.nextalone.util.hookAfter
@@ -63,6 +65,25 @@ object ChatInputHint : CommonConfigFunctionHook("na_chat_input_hint", arrayOf(NB
     private const val strCfg = "na_chat_input_hint_str"
 
     override fun initOnce(): Boolean = throwOrTrue {
+        if (requireMinTimVersion(TIMVersion.TIM_4_0_98)) {
+            // 7f116adf -> 说点什么...
+            // Lcom/tencent/tim/aio/inputbar/simpleui/a;->v()V
+            // Lcom/tencent/tim/aio/inputbar/simpleui/TimAIOInputSimpleUIVBDelegate;->B()V
+            "Lcom/tencent/tim/aio/inputbar/simpleui/a;->v()V".method.hookAfter(this) {
+                it.thisObject.javaClass.declaredFields.single { it.type == EditText::class.java }.apply {
+                    isAccessible = true
+                    val et = get(it.thisObject) as EditText
+                    et.hint = getValue()
+                }
+            }
+            "Lcom/tencent/tim/aio/inputbar/simpleui/TimAIOInputSimpleUIVBDelegate;->B()V".method.hookAfter(this) {
+                it.thisObject.javaClass.declaredFields.single { it.type == EditText::class.java }.apply {
+                    isAccessible = true
+                    val et = get(it.thisObject) as EditText
+                    et.hint = getValue()
+                }
+            }
+        }
         if (requireMinQQVersion(QQVersion.QQ_8_9_63_BETA_11345)) {
             // 私聊 && QQ9.0.35版本后的群聊
             DexKit.requireMethodFromCache(AIO_InputRootInit_QQNT).hookAfter(this) {


### PR DESCRIPTION
# 标题 / Title Here

聊天框设置提示文本 for TIM NT 4.0.98

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description

添加 Hook 点如下

Lcom/tencent/tim/aio/inputbar/simpleui/TimAIOInputSimpleUIVBDelegate;->B()V

Lcom/tencent/tim/aio/inputbar/simpleui/a;->v()V

<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR

未知

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [ ] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
