### PR TITLE
ui: night mode text for TimBarAddEssence

### DIFF
--- a/app/src/main/java/me/hd/hook/TimBarAddEssenceHook.kt
+++ b/app/src/main/java/me/hd/hook/TimBarAddEssenceHook.kt
@@ -42,6 +42,7 @@ import io.github.qauxv.util.Initiator
 import io.github.qauxv.util.TIMVersion
 import io.github.qauxv.util.Toasts
 import io.github.qauxv.util.requireMinTimVersion
+import io.github.qauxv.ui.ResUtils
 
 @FunctionHookEntry
 @UiItemAgentEntry
@@ -70,14 +71,18 @@ object TimBarAddEssenceHook : CommonSwitchFunctionHook(), IAIOParamUpdate {
                     id = Layout_Id
                     text = "精"
                     textSize = 16f
-                    setTextColor(Color.BLACK)
+                    if (ResUtils.isInNightMode()) {
+                        setTextColor(Color.WHITE)
+                    } else {
+                        setTextColor(Color.BLACK)
+                    }
                     layoutParams = RelativeLayout.LayoutParams(
                         RelativeLayout.LayoutParams.WRAP_CONTENT,
                         RelativeLayout.LayoutParams.WRAP_CONTENT
                     ).apply {
                         addRule(RelativeLayout.ALIGN_PARENT_RIGHT)
                         addRule(RelativeLayout.CENTER_VERTICAL)
-                        marginEnd = XPopupUtils.dp2px(view.context, 60f)
+                        marginEnd = XPopupUtils.dp2px(view.context, 70f)
                     }
                 }
                 textView.setOnClickListener {


### PR DESCRIPTION
# 标题 / Title Here

为 TimBarAddEssence 的文字 适配夜间模式
并增大字与按钮间间隔
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description

1. 加大 "精" 与右上角更多之间的间隔
2. 夜间模式时使用白色文字
<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [ ] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)

我真傻, 明明可以直接合并的(?), 我怎么还要再merge到分支一次(x