### PR TITLE
feat: hide group assistant banner

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -4,6 +4,7 @@
 -keep class cc.** { *; }
 -keep class io.** { *; }
 -keep class org.** { *; }
+-keep class com.enlysure.** { *; }
 -keep class com.microsoft.** { *; }
 -keep class com.rymmmmm.** { *; }
 -keep class com.codepwn.** { *; }

--- a/app/src/main/java/com/enlysure/hook/HideGroupAssistantBanner.kt
+++ b/app/src/main/java/com/enlysure/hook/HideGroupAssistantBanner.kt
@@ -1,0 +1,51 @@
+/*
+ * QAuxiliary - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2025 QAuxiliary developers
+ * https://github.com/cinit/QAuxiliary
+ *
+ * This software is an opensource software: you can redistribute it
+ * and/or modify it under the terms of the General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version as published
+ * by QAuxiliary contributors.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the General Public License for more details.
+ *
+ * You should have received a copy of the General Public License
+ * along with this software.
+ * If not, see
+ * <https://github.com/cinit/QAuxiliary/blob/master/LICENSE.md>.
+ */
+
+package com.enlysure.hook
+
+import android.view.View
+import cc.ioctl.util.hookAfterIfEnabled
+import io.github.qauxv.base.annotation.FunctionHookEntry
+import io.github.qauxv.base.annotation.UiItemAgentEntry
+import io.github.qauxv.dsl.FunctionEntryRouter
+import io.github.qauxv.hook.CommonSwitchFunctionHook
+import io.github.qauxv.util.Initiator
+
+@FunctionHookEntry
+@UiItemAgentEntry
+object HideGroupAssistantBanner : CommonSwitchFunctionHook() {
+
+    override val name = "隐藏群助手顶部Banner提示"
+
+    override val description = "隐藏群助手顶部'收进群助手且不提醒'的Banner"
+
+    override val uiItemLocation = FunctionEntryRouter.Locations.Simplify.CHAT_GROUP_OTHER
+
+    override fun initOnce(): Boolean {
+        val createTopBannerMethod = Initiator.loadClass("com/tencent/mobileqq/activity/home/chats/troophelper/TroopHelperFragment")
+            .getDeclaredMethod("createTopBanner")
+        hookAfterIfEnabled(createTopBannerMethod) { param ->
+            (param.result as View).visibility = View.GONE
+        }
+        return true
+    }
+}

--- a/app/src/main/java/com/enlysure/hook/HideGroupAssistantBanner.kt
+++ b/app/src/main/java/com/enlysure/hook/HideGroupAssistantBanner.kt
@@ -36,7 +36,7 @@ object HideGroupAssistantBanner : CommonSwitchFunctionHook() {
 
     override val name = "隐藏群助手顶部Banner提示"
 
-    override val description = "隐藏群助手顶部'收进群助手且不提醒'的Banner"
+    override val description = "隐藏群助手顶部 '以下为\"收进群助手且不提醒\"的群消息：' 的提示"
 
     override val uiItemLocation = FunctionEntryRouter.Locations.Simplify.CHAT_GROUP_OTHER
 

--- a/app/src/main/java/xyz/nextalone/hook/SimplifyContactTabs.kt
+++ b/app/src/main/java/xyz/nextalone/hook/SimplifyContactTabs.kt
@@ -25,7 +25,9 @@ import io.github.qauxv.base.annotation.FunctionHookEntry
 import io.github.qauxv.base.annotation.UiItemAgentEntry
 import io.github.qauxv.dsl.FunctionEntryRouter
 import io.github.qauxv.util.QQVersion
+import io.github.qauxv.util.TIMVersion
 import io.github.qauxv.util.requireMinQQVersion
+import io.github.qauxv.util.requireMinTimVersion
 import xyz.nextalone.base.MultiItemDelayableHook
 import xyz.nextalone.util.*
 
@@ -37,10 +39,10 @@ object SimplifyContactTabs : MultiItemDelayableHook("na_simplify_contact_tabs_mu
     override val allItems = setOf("好友", "分组", "群聊", "设备", "通讯录", "订阅号", "推荐", "频道", "机器人")
     override val defaultItems = setOf<String>()
     override val uiItemLocation = FunctionEntryRouter.Locations.Simplify.MAIN_UI_CONTACT
-    override val isAvailable = requireMinQQVersion(QQVersion.QQ_8_5_5)
+    override val isAvailable = requireMinQQVersion(QQVersion.QQ_8_5_5) || requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA)
 
     override fun initOnce() = throwOrTrue {
-        val nameContactsTabs = if (requireMinQQVersion(QQVersion.QQ_8_9_2)) "b" else "ContactsTabs"
+        val nameContactsTabs = if (requireMinQQVersion(QQVersion.QQ_8_9_2) || requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA)) "b" else "ContactsTabs"
         "Lcom.tencent.mobileqq.activity.contacts.base.tabs.$nameContactsTabs;->a()V".method.hookAfter(this) {
 
             val listTabId: ArrayList<Int> = arrayListOf()


### PR DESCRIPTION
# 标题 / Title Here


## 描述 / Description

新增功能：隐藏群助手顶部的 _收进群助手且不提醒_ 的banner （已测试兼容qq nt和tim nt）
修改：让联系人页面精简在tim nt上生效

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List


- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
