### PR TITLE
feat: HideChatDatabaseCorruptDialog on TIM_NT 4.0.98

### DIFF
--- a/app/src/main/java/io/github/moonleeeaf/hook/HideChatDatabaseCorruptDialogHook.java
+++ b/app/src/main/java/io/github/moonleeeaf/hook/HideChatDatabaseCorruptDialogHook.java
@@ -1,0 +1,82 @@
+package io.github.moonleeeaf.hook;
+
+/*
+ * QAuxiliary - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2022 qwq233@qwq2333.top
+ * https://github.com/cinit/QAuxiliary
+ *
+ * This software is non-free but opensource software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version and our eula as published
+ * by QAuxiliary contributors.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * and eula along with this software.  If not, see
+ * <https://www.gnu.org/licenses/>
+ * <https://github.com/cinit/QAuxiliary/blob/master/LICENSE.md>.
+ */
+
+import android.app.Activity;
+import android.os.Bundle;
+import androidx.annotation.NonNull;
+import cc.ioctl.util.HookUtils;
+import io.github.qauxv.base.annotation.FunctionHookEntry;
+import io.github.qauxv.base.annotation.UiItemAgentEntry;
+import io.github.qauxv.dsl.FunctionEntryRouter;
+import io.github.qauxv.hook.CommonSwitchFunctionHook;
+import io.github.qauxv.util.Initiator;
+import java.lang.reflect.Method;
+
+@FunctionHookEntry
+@UiItemAgentEntry
+public class HideChatDatabaseCorruptDialogHook extends CommonSwitchFunctionHook {
+
+    public static final HideChatDatabaseCorruptDialogHook INSTANCE = new HideChatDatabaseCorruptDialogHook();
+
+    private HideChatDatabaseCorruptDialogHook() {
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "屏蔽聊天记录异常对话框";
+    }
+
+    @NonNull
+    @Override
+    public String getDescription() {
+        return "导入聊天记录数据库偶遇大粪qQ脑瘫不认库, 每次切换页面关图片弹对话框, 修复未果无法关闭(对话框), 拼尽全力无法憋笑";
+    }
+
+    @NonNull
+    @Override
+    public String[] getUiItemLocation() {
+        return FunctionEntryRouter.Locations.Simplify.UI_MISC;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        //暂时无法确定该类是什么时候添加的
+        return Initiator.load("com.tencent.mobileqq.database.corrupt.DBFixDialogUI") != null;
+    }
+
+    @Override
+    public boolean initOnce() throws Exception {
+        // 7f113d58
+        // Lcom/tencent/mobileqq/database/corrupt/DBFixDialogUI;->v(I)V
+        Method mMethod = Initiator.loadClass("com.tencent.mobileqq.database.corrupt.DBFixDialogUI")
+                .getDeclaredMethod("v", int.class);
+
+        HookUtils.hookBeforeIfEnabled(this, mMethod, (param) -> {
+            param.setResult(null);
+        });
+        return true;
+    }
+
+}


### PR DESCRIPTION
# 屏蔽聊天记录异常对话框
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description

导入聊天记录数据库偶遇大粪qQ脑瘫不认库, 每次切换页面关图片弹对话框, 修复未果无法关闭(对话框), 拼尽全力无法憋笑

![Screenshot_20250202-194600_TIM_1](https://github.com/user-attachments/assets/dd628d06-56f4-4a9c-80d9-8e5db080fe92)

![Screenshot_20250202-194611_TIM_1](https://github.com/user-attachments/assets/ac5e9e07-85ce-4287-9adc-2be6496f22c7)

<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [ ] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)

