### PR TITLE
fix: HookUpgrade on QQ 8.2.11

### DIFF
--- a/app/src/main/java/com/alphi/qhmk/module/HookUpgrade.java
+++ b/app/src/main/java/com/alphi/qhmk/module/HookUpgrade.java
@@ -42,7 +42,13 @@ public class HookUpgrade extends CommonSwitchFunctionHook {
         } catch (Exception ignored) {
         }
 
-        Class<?> configHandlerClass = Initiator.loadClass("com.tencent.mobileqq.app.ConfigHandler");
+        Class<?> configHandlerClass;
+        configHandlerClass = Initiator.load("com.tencent.mobileqq.app.ConfigHandler");
+        if (configHandlerClass == null && HostInfo.requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11))
+            configHandlerClass = Initiator.load("ajsf");
+        if (configHandlerClass == null)
+            throw new RuntimeException("HookUpgrade: ConfigHandler not found");
+
         for (Method m : configHandlerClass.getDeclaredMethods()) {
             Class<?>[] parameterTypes = m.getParameterTypes();
             if (m.getReturnType() == void.class && parameterTypes.length == 1 && parameterTypes[0].getSimpleName().equals("UpgradeDetailWrapper")) {
@@ -52,12 +58,12 @@ public class HookUpgrade extends CommonSwitchFunctionHook {
 
         Class<?> upgc;
         upgc = Initiator.load("com.tencent.mobileqq.upgrade.UpgradeController");
-        if (upgc == null) {
+        if (upgc == null)
             upgc = Initiator.load("com.tencent.mobileqq.app.upgrade.UpgradeController");
-        }
-        if (upgc == null) {
+        if (upgc == null && HostInfo.requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11))
+            upgc = Initiator.load("aksy");
+        if (upgc == null)
             throw new RuntimeException("HookUpgrade: UpgradeController not found");
-        }
 
         for (Method m : upgc.getDeclaredMethods()) {
             if (m.getReturnType() == void.class) {


### PR DESCRIPTION
# 修复QQ8.2.11上的屏蔽更新

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description
如题
<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR
如题
## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
