### PR TITLE
fix: RemovePlayTogether on QQ 8.2.11

### DIFF
--- a/app/src/main/java/cc/ioctl/hook/troop/RemovePlayTogether.kt
+++ b/app/src/main/java/cc/ioctl/hook/troop/RemovePlayTogether.kt
@@ -33,6 +33,8 @@ import io.github.qauxv.tlb.ConfigTable
 import xyz.nextalone.util.method
 import xyz.nextalone.util.replace
 import xyz.nextalone.util.throwOrTrue
+import io.github.qauxv.util.PlayQQVersion
+import io.github.qauxv.util.requireRangePlayQQVersion
 
 //屏蔽群聊界面一起嗨
 @FunctionHookEntry
@@ -46,13 +48,15 @@ object RemovePlayTogether : CommonSwitchFunctionHook() {
     const val ClockInEntryHelper = "RemovePlayTogether.ClockInEntryHelper"
     const val TogetherControlHelper = "RemovePlayTogether.TogetherControlHelper"
     public override fun initOnce(): Boolean = throwOrTrue {
-        if (requireMinQQVersion(QQVersion.QQ_8_4_8)) {
-            //QQ 8.4.8 除了一起嗨按钮，同一个位置还有一个群打卡按钮。默认显示群打卡，如果已经打卡就显示一起嗨，两个按钮点击之后都会打开同一个界面，但是要同时hook两个
-            Initiator._ClockInEntryHelper()?.method(ConfigTable.getConfig(ClockInEntryHelper), 0, Boolean::class.java)?.replace(this, result = false)
+        if (isPlayQQ()) {
+            if (requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11))
+                Initiator.loadClass("adhn").getDeclaredMethod("h").replace(this, result = false)
+        } else {
+            if (requireMinQQVersion(QQVersion.QQ_8_4_8)) {
+                //QQ 8.4.8 除了一起嗨按钮，同一个位置还有一个群打卡按钮。默认显示群打卡，如果已经打卡就显示一起嗨，两个按钮点击之后都会打开同一个界面，但是要同时hook两个
+                Initiator._ClockInEntryHelper()?.method(ConfigTable.getConfig(ClockInEntryHelper), 0, Boolean::class.java)?.replace(this, result = false)
+            }
+            Initiator._TogetherControlHelper()?.method(ConfigTable.getConfig(TogetherControlHelper), 0, Void.TYPE)?.replace(this, result = null)
         }
-        Initiator._TogetherControlHelper()?.method(ConfigTable.getConfig(TogetherControlHelper), 0, Void.TYPE)?.replace(this, result = null)
     }
-
-    override val isAvailable: Boolean
-        get() = !isPlayQQ()
 }


### PR DESCRIPTION
# 修复QQ8.2.11上的 屏蔽群聊界面一起嗨

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description
如题
<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
