### PR TITLE
Fixed some things on QQ 8.2.11

### DIFF
--- a/app/src/main/java/cc/hicore/hook/ShowAccurateGaggedTime.java
+++ b/app/src/main/java/cc/hicore/hook/ShowAccurateGaggedTime.java
@@ -36,6 +36,7 @@ import io.github.qauxv.hook.CommonSwitchFunctionHook;
 import io.github.qauxv.util.Initiator;
 import io.github.qauxv.util.QQVersion;
 import io.github.qauxv.util.TIMVersion;
+import io.github.qauxv.util.PlayQQVersion;
 
 @FunctionHookEntry
 @UiItemAgentEntry
@@ -74,18 +75,32 @@ public class ShowAccurateGaggedTime extends CommonSwitchFunctionHook {
             return true;
         }
 
-        HookUtils.hookBeforeIfEnabled(this,
-                Reflex.findMethod(Initiator.loadClass("com.tencent.mobileqq.troop.troopgag.api.impl.TroopGagServiceImpl"), String.class,
-                        "gagTimeToStringCountDown", Context.class, long.class), param -> {
-                    long time = (long) param.args[1] + 30;
-                    long serverTime = AppRuntimeHelper.getServerTime();
-                    time = time - serverTime;
-                    if (time <= 0) {
-                        param.setResult("[解禁了,返回再进吧]");
-                        return;
-                    }
-                    param.setResult(secondToTime(time));
-                });
+        if (io.github.qauxv.util.HostInfo.requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11))
+            HookUtils.hookBeforeIfEnabled(this,
+                    Reflex.findMethod(Initiator.loadClass("bahd"), String.class,
+                            "b", Context.class, long.class), param -> {
+                        long time = (long) param.args[1] - 2;
+                        long serverTime = AppRuntimeHelper.getServerTime();
+                        time = time - serverTime;
+                        if (time <= 0) {
+                            param.setResult("[解禁了,返回再进吧]");
+                            return;
+                        }
+                        param.setResult(secondToTime(time));
+                    });
+        else
+            HookUtils.hookBeforeIfEnabled(this,
+                    Reflex.findMethod(Initiator.loadClass("com.tencent.mobileqq.troop.troopgag.api.impl.TroopGagServiceImpl"), String.class,
+                            "gagTimeToStringCountDown", Context.class, long.class), param -> {
+                        long time = (long) param.args[1] + 30;
+                        long serverTime = AppRuntimeHelper.getServerTime();
+                        time = time - serverTime;
+                        if (time <= 0) {
+                            param.setResult("[解禁了,返回再进吧]");
+                            return;
+                        }
+                        param.setResult(secondToTime(time));
+                    });
 
         HookUtils.hookBeforeIfEnabled(this, Reflex.findSingleMethod(Initiator._TroopGagMgr(),
                 String.class, false, Context.class, long.class, long.class), param -> {

--- a/app/src/main/java/cc/hicore/hook/UnlockLeftSlipLimit.java
+++ b/app/src/main/java/cc/hicore/hook/UnlockLeftSlipLimit.java
@@ -38,6 +38,7 @@ import io.github.qauxv.util.dexkit.NLeftSwipeReplyHelper_reply;
 import io.github.qauxv.util.xpcompat.XC_MethodHook;
 import io.github.qauxv.util.xpcompat.XposedHelpers;
 import java.lang.reflect.Method;
+import io.github.qauxv.util.PlayQQVersion;
 
 @FunctionHookEntry
 @UiItemAgentEntry
@@ -72,7 +73,7 @@ public class UnlockLeftSlipLimit extends CommonSwitchFunctionHook {
             return true;
         }
         Method m = XMethod.clz(DexKit.requireMethodFromCache(NLeftSwipeReplyHelper_reply.INSTANCE).getDeclaringClass())
-                .name(!HostInfo.requireMinQQVersion(QQVersion.QQ_8_8_93) ? "h" : HostInfo.requireMinQQVersion(QQVersion.QQ_8_9_33) ? "I" : "H")
+                .name(io.github.qauxv.util.HostInfo.requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11) ? "c" : !HostInfo.requireMinQQVersion(QQVersion.QQ_8_8_93) ? "h" : HostInfo.requireMinQQVersion(QQVersion.QQ_8_9_33) ? "I" : "H")
                 .ret(boolean.class)
                 .get();
         HookUtils.hookBeforeIfEnabled(this, m, param -> param.setResult(true));

--- a/app/src/main/java/cc/ioctl/hook/ui/title/RemoveCameraButton.kt
+++ b/app/src/main/java/cc/ioctl/hook/ui/title/RemoveCameraButton.kt
@@ -34,6 +34,11 @@ import io.github.qauxv.util.QQVersion
 import io.github.qauxv.util.isTim
 import io.github.qauxv.util.requireMinQQVersion
 import xyz.nextalone.util.throwOrTrue
+import top.linl.util.reflect.FieldUtils
+import android.widget.ImageView
+import cc.ioctl.util.hookAfterIfEnabled
+import io.github.qauxv.util.PlayQQVersion
+import io.github.qauxv.util.requireRangePlayQQVersion
 
 @FunctionHookEntry
 @UiItemAgentEntry
@@ -55,18 +60,25 @@ object RemoveCameraButton : CommonSwitchFunctionHook("kr_disable_camera_button")
         }.hookBefore {
             if (!isEnabled) return@hookBefore; it.result = null
         }
-        findMethod(Initiator._ConversationTitleBtnCtrl()) {
-            val methodName = when {
-                requireMinQQVersion(QQVersion.QQ_8_9_63_BETA_11345) -> "C"
-                requireMinQQVersion(QQVersion.QQ_8_9_10) -> "B"
-                requireMinQQVersion(QQVersion.QQ_8_9_5) -> "E"
-                requireMinQQVersion(QQVersion.QQ_8_8_93) -> "F"
-                else -> "a"
+        if (requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11))
+            hookAfterIfEnabled(Initiator.loadClass("aawg").getDeclaredMethod("a")) { param ->
+                val view = FieldUtils.getField(param.thisObject, "a", android.widget.ImageView::class.java) as ImageView
+                view.visibility = View.GONE
+                FieldUtils.setField(param.thisObject, "a", android.widget.ImageView::class.java, view)
             }
-            name == methodName && returnType == Void.TYPE && parameterTypes.isEmpty()
-        }.hookBefore {
-            if (!isEnabled) return@hookBefore; it.result = null
-        }
+        else
+            findMethod(Initiator._ConversationTitleBtnCtrl()) {
+                val methodName = when {
+                    requireMinQQVersion(QQVersion.QQ_8_9_63_BETA_11345) -> "C"
+                    requireMinQQVersion(QQVersion.QQ_8_9_10) -> "B"
+                    requireMinQQVersion(QQVersion.QQ_8_9_5) -> "E"
+                    requireMinQQVersion(QQVersion.QQ_8_8_93) -> "F"
+                    else -> "a"
+                }
+                name == methodName && returnType == Void.TYPE && parameterTypes.isEmpty()
+            }.hookBefore {
+                if (!isEnabled) return@hookBefore; it.result = null
+            }
     }
 
     override val uiItemLocation: Array<String> = FunctionEntryRouter.Locations.Simplify.MAIN_UI_TITLE


### PR DESCRIPTION
# 修复QQ8.2.11上的 被禁言剩余时间精确到秒 && 屏蔽消息界面标题栏相机图标 &&  允许各种消息左滑回复

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description
如题
<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
