### PR TITLE
feat: BlockBusCard

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -24,6 +24,7 @@
 -keep class io.github.fusumayuki.** { *; }
 -keep class awoo.linwenxuan04.** { *; }
 -keep class wang.allenyou.** { *; }
+-keep buscard.** { *; }
 
 -keepclasseswithmembernames class * {
     native <methods>;

--- a/app/src/main/java/buscard/cooperation/BlockBusCard.java
+++ b/app/src/main/java/buscard/cooperation/BlockBusCard.java
@@ -1,0 +1,76 @@
+/*
+ * QAuxiliary - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2025 QAuxiliary developers
+ * https://github.com/cinit/QAuxiliary
+ *
+ * This software is an opensource software: you can redistribute it
+ * and/or modify it under the terms of the General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version as published
+ * by QAuxiliary contributors.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the General Public License for more details.
+ *
+ * You should have received a copy of the General Public License
+ * along with this software.
+ * If not, see
+ * <https://github.com/cinit/QAuxiliary/blob/master/LICENSE.md>.
+ */
+
+package buscard.cooperation;
+
+import android.content.Intent;
+import androidx.annotation.NonNull;
+import cc.ioctl.util.HookUtils;
+import io.github.qauxv.base.annotation.FunctionHookEntry;
+import io.github.qauxv.base.annotation.UiItemAgentEntry;
+import io.github.qauxv.dsl.FunctionEntryRouter;
+import io.github.qauxv.hook.CommonSwitchFunctionHook;
+import io.github.qauxv.util.Initiator;
+import io.github.qauxv.util.QQVersion;
+import io.github.qauxv.util.HostInfo;
+import java.lang.reflect.Method;
+
+@FunctionHookEntry
+@UiItemAgentEntry
+public final class BlockBusCard extends CommonSwitchFunctionHook {
+
+    public static final BlockBusCard INSTANCE = new BlockBusCard();
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "禁用QQ公交卡";
+    }
+
+    @Override
+    public String getDescription() {
+        return "禁止QQ在后台干扰NFC";
+    }
+
+    @NonNull
+    @Override
+    public String[] getUiItemLocation() {
+        return FunctionEntryRouter.Locations.Auxiliary.MISC_CATEGORY;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return HostInfo.requireMaxQQVersion(QQVersion.QQ_8_4_10);
+    }
+
+    @Override
+    public boolean initOnce() throws Exception {
+        Class<?> helper = Initiator.loadClass("cooperation.buscard.BuscardHelper");
+        for (Method m : helper.getDeclaredMethods()) {
+            for (Class<?> parameterType : m.getParameterTypes()) {
+                if (parameterType.equals(Intent.class))
+                    HookUtils.hookBeforeIfEnabled(this, m, param -> param.setResult(null));
+            }
+        }
+        return true;
+    }
+}

--- a/app/src/main/java/io/github/qauxv/fragment/PendingFunctionFragment.kt
+++ b/app/src/main/java/io/github/qauxv/fragment/PendingFunctionFragment.kt
@@ -93,7 +93,6 @@ class PendingFunctionFragment : BaseRootLayoutFragment() {
         Item("屏蔽卡片消息 IP 探针", "可能导致部分卡片消息无法正常显示", null, true),
         Item("QQ电话关麦时解除占用", "再开麦时如麦被其他程序占用可能崩溃", null, true),
         Item("QQ视频通话旋转锁定", "可在通话界面设置旋转方向", null, true),
-        Item("禁用QQ公交卡", "禁止QQ在后台干扰NFC", null, true),
         Item("阻挡QQ获取位置信息", "重定向到(0,0)或PEK中心", null, true),
         Item("阻挡QQ检测权限未授予", "如 定位 联系人等隐私权限 ", null, true),
     )


### PR DESCRIPTION
# 禁用QQ公交卡

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description
碰到nfc标签时,qq不会再弹出此窗口
![S50319-20345169(1)](https://github.com/user-attachments/assets/4210c89b-b9e0-45a4-8f1b-a75eff16146e)


在碰到nfc标签时,如果qq不在运行,仍会启动qq,这是因为 com.tencent.mobileqq.activity.JumpActivity 注册了 android.nfc.action.TECH_DISCOVERED , nfc服务会向其发送intent启动它
<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
