### PR TITLE
Fix some custom functions on QQ 8.2.11

### DIFF
--- a/app/src/main/java/cc/ioctl/hook/sideswipe/SimplifyQQSettingMe.kt
+++ b/app/src/main/java/cc/ioctl/hook/sideswipe/SimplifyQQSettingMe.kt
@@ -66,6 +66,8 @@ import xyz.nextalone.util.*
 import java.lang.reflect.Array
 import java.lang.reflect.Modifier
 import java.util.SortedMap
+import io.github.qauxv.util.PlayQQVersion
+import io.github.qauxv.util.requireRangePlayQQVersion
 
 //侧滑栏精简
 @FunctionHookEntry
@@ -86,7 +88,7 @@ object SimplifyQQSettingMe :
     override val description: String = "可能需要重启 QQ 后生效"
     override val allItems = setOf<String>()
     override val uiItemLocation = FunctionEntryRouter.Locations.Simplify.SLIDING_UI
-    override val isAvailable = requireMinQQVersion(QQ_8_4_1)
+    override val isAvailable = requireMinQQVersion(QQ_8_4_1) || requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11)
     override val enableCustom = false
 
     //Form 8.4.1

--- a/app/src/main/java/io/github/qauxv/tlb/PlayQQConfigTable.kt
+++ b/app/src/main/java/io/github/qauxv/tlb/PlayQQConfigTable.kt
@@ -45,6 +45,10 @@ class PlayQQConfigTable : ConfigTableInterface {
         SortAtPanel.sessionInfoTroopUin to mapOf(
             PlayQQ_8_2_11 to "a",
         ),
+
+        SimplifyQQSettingMe.MidContentName to mapOf(
+            PlayQQ_8_2_11 to "k",
+        ),
     )
 
 }

--- a/app/src/main/java/me/hd/hook/HideChatPanelBtn.kt
+++ b/app/src/main/java/me/hd/hook/HideChatPanelBtn.kt
@@ -32,6 +32,9 @@ import io.github.qauxv.util.Initiator
 import io.github.qauxv.util.QQVersion
 import io.github.qauxv.util.requireMinQQVersion
 import xyz.nextalone.base.MultiItemDelayableHook
+import io.github.qauxv.util.PlayQQVersion
+import io.github.qauxv.util.requireRangePlayQQVersion
+import cc.ioctl.util.hookBeforeIfEnabled
 
 @FunctionHookEntry
 @UiItemAgentEntry
@@ -39,21 +42,37 @@ object HideChatPanelBtn : MultiItemDelayableHook(
     keyName = "hd_HideChatPanelBtn"
 ) {
     override val preferenceTitle = "屏蔽聊天面板按钮"
-    override val allItems = setOf("语音", "拍照", "红包", "表情", "更多功能")
+    override val allItems = if (requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11)) setOf("语音", "图片", "拍照", "红包", "表情", "更多功能") else setOf("语音", "拍照", "红包", "表情", "更多功能")
     override val defaultItems = setOf<String>()
     override val uiItemLocation = FunctionEntryRouter.Locations.Simplify.CHAT_OTHER
-    override val isAvailable = requireMinQQVersion(QQVersion.QQ_8_9_88)
+    override val isAvailable = requireMinQQVersion(QQVersion.QQ_8_9_88) || requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11)
 
     override fun initOnce(): Boolean {
-        val panelIconClass = Initiator.loadClass("com.tencent.qqnt.aio.shortcutbar.PanelIconLinearLayout")
-        val iconItemMethod = panelIconClass.declaredMethods.single { method ->
-            method.returnType == ImageView::class.java
-        }
-        hookAfterIfEnabled(iconItemMethod) { param ->
-            val imageView = param.result as ImageView
-            val contentDesc = imageView.contentDescription
-            if (activeItems.contains(contentDesc)) {
-                imageView.visibility = View.GONE
+        if (requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11)) {
+            hookBeforeIfEnabled(Initiator.loadClass("ayil").getDeclaredMethod("b", android.content.Context::class.java, View::class.java)) { param ->
+                val bar = param.args[1] as View
+                val allItemsMap = mapOf(
+                    "语音" to bar.findViewById<View>(0x7f0a2b72),
+                    "图片" to bar.findViewById<View>(0x7f0a2b68),
+                    "拍照" to bar.findViewById<View>(0x7f0a2b75),
+                    "红包" to bar.findViewById<View>(0x7f0a2b60),
+                    "表情" to bar.findViewById<View>(0x7f0a2b56),
+                    "更多功能" to bar.findViewById<View>(0x7f0a2b6d)
+                )
+                for (item in activeItems)
+                    allItemsMap[item]?.visibility = View.GONE
+            }
+        } else {
+            val panelIconClass = Initiator.loadClass("com.tencent.qqnt.aio.shortcutbar.PanelIconLinearLayout")
+            val iconItemMethod = panelIconClass.declaredMethods.single { method ->
+                method.returnType == ImageView::class.java
+            }
+            hookAfterIfEnabled(iconItemMethod) { param ->
+                val imageView = param.result as ImageView
+                val contentDesc = imageView.contentDescription
+                if (activeItems.contains(contentDesc)) {
+                    imageView.visibility = View.GONE
+                }
             }
         }
         return true

--- a/app/src/main/java/xyz/nextalone/hook/SimplifyEmoPanel.kt
+++ b/app/src/main/java/xyz/nextalone/hook/SimplifyEmoPanel.kt
@@ -34,6 +34,11 @@ import xyz.nextalone.util.get
 import xyz.nextalone.util.hookBefore
 import xyz.nextalone.util.method
 import xyz.nextalone.util.throwOrTrue
+import cc.ioctl.util.hookBeforeIfEnabled
+import io.github.qauxv.util.Initiator
+import io.github.qauxv.util.PlayQQVersion
+import io.github.qauxv.util.requireRangePlayQQVersion
+import top.linl.util.reflect.FieldUtils
 
 @FunctionHookEntry
 @UiItemAgentEntry
@@ -83,7 +88,17 @@ object SimplifyEmoPanel : MultiItemDelayableHook("na_simplify_emo_panel") {
 //                    it2.result = view
 //                }
         }
+        if (requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11)) {
+            hookBeforeIfEnabled(Initiator.loadClass("com.tencent.mobileqq.emoticonview.EmoticonMainPanel").getDeclaredMethod("c", Int::class.java)) { param ->
+                val mutableList = FieldUtils.getField(param.thisObject, "a", java.util.List::class.java) as MutableList<*>
+                mutableList.removeAll { item ->
+                    if (item == null) return@removeAll false
+                    val i = FieldUtils.getField(item, "a", Int::class.java) as Int
+                    allItemsDict[i] in activeItems || i !in allItemsDict.keys && "表情包" in activeItems
+                }
+            }
+        }
     }
 
-    override val isAvailable: Boolean get() = requireMinQQVersion(QQVersion.QQ_8_5_5) || requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA)
+    override val isAvailable: Boolean get() = requireMinQQVersion(QQVersion.QQ_8_5_5) || requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) || requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11)
 }

--- a/app/src/main/java/xyz/nextalone/hook/SimplifyRecentDialog.kt
+++ b/app/src/main/java/xyz/nextalone/hook/SimplifyRecentDialog.kt
@@ -34,6 +34,8 @@ import xyz.nextalone.util.get
 import xyz.nextalone.util.hookBefore
 import xyz.nextalone.util.method
 import xyz.nextalone.util.throwOrTrue
+import io.github.qauxv.util.PlayQQVersion
+import io.github.qauxv.util.requireRangePlayQQVersion
 
 @FunctionHookEntry
 @UiItemAgentEntry
@@ -56,10 +58,13 @@ object SimplifyRecentDialog : MultiItemDelayableHook("na_simplify_recent_dialog_
             methodName = "b"
             titleName = "a"
         }
-        "com/tencent/widget/PopupMenuDialog".clazz?.method(
+        var target = "com/tencent/widget/PopupMenuDialog".clazz
+        if (requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11))
+            target = "bfqp".clazz
+        target?.method(
             methodName,
             4,
-            "com.tencent.widget.PopupMenuDialog".clazz
+            target
         )?.hookBefore(this) {
             val list = (it.args[1] as List<*>).toMutableList()
             val iterator = list.iterator()
@@ -73,5 +78,5 @@ object SimplifyRecentDialog : MultiItemDelayableHook("na_simplify_recent_dialog_
         }
     }
 
-    override val isAvailable: Boolean get() = requireMinQQVersion(QQVersion.QQ_8_3_9) || requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA)
+    override val isAvailable: Boolean get() = requireMinQQVersion(QQVersion.QQ_8_3_9) || requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) || requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11)
 }


### PR DESCRIPTION
# 修复QQ8.2.11上的 精简表情菜单 && 精简主页加号菜单 && 屏蔽聊天面板按钮 && 侧滑栏精简

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description
如题
<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
