### PR TITLE
Added a function BlockLinkInfo

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -24,6 +24,7 @@
 -keep class io.github.fusumayuki.** { *; }
 -keep class awoo.linwenxuan04.** { *; }
 -keep class wang.allenyou.** { *; }
+-keep class im.mingxi.** { *; }
 
 -keepclasseswithmembernames class * {
     native <methods>;

--- a/app/src/main/java/im/mingxi/BlockLinkInfo.kt
+++ b/app/src/main/java/im/mingxi/BlockLinkInfo.kt
@@ -1,0 +1,30 @@
+package im.mingxi
+
+import io.github.qauxv.base.annotation.FunctionHookEntry
+import io.github.qauxv.base.annotation.UiItemAgentEntry
+import io.github.qauxv.dsl.FunctionEntryRouter
+import io.github.qauxv.hook.CommonSwitchFunctionHook
+import io.github.qauxv.util.Initiator
+import io.github.qauxv.util.xpcompat.XC_MethodHook
+import io.github.qauxv.util.xpcompat.XposedBridge
+
+@FunctionHookEntry
+@UiItemAgentEntry
+object RemoveShakeAdExampleHook : CommonSwitchFunctionHook() {
+
+    override val name = "屏蔽链接信息"
+
+    override val description = "去除链接下方的信息卡片，也可以用来防耗流量链接消息"
+
+    override val uiItemLocation: Array<String> = FunctionEntryRouter.Locations.Auxiliary.CHAT_CATEGORY
+
+    override fun initOnce(): Boolean {
+        val linkInfoClass = Initiator.loadClass("com.tencent.qqnt.kernel.nativeinterface.LinkInfo")
+        XposedBridge.hookAllConstructors(linkInfoClass, object: XC_MethodHook() {
+            override fun beforeHookedMethod(param: MethodHookParam) {
+                param.result = null
+            }
+        })
+        return true
+    }
+}


### PR DESCRIPTION
# 标题 / Title Here
添加功能"屏蔽链接信息"
## 描述 / Description
屏蔽链接文本消息下方的链接卡片，此功能位于FunctionEntryRouter.Locations.Auxiliary.CHAT_CATEGORY，也许可以提供情绪价值，肯定可以屏蔽耗流量链接。


## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [ ✔] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [✔ ] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [ ✔] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
