### PR TITLE
Fix Something on QQ 9.1.50+

### DIFF
--- a/app/src/main/java/cc/ioctl/hook/troop/TroopFileSaveLasting.kt
+++ b/app/src/main/java/cc/ioctl/hook/troop/TroopFileSaveLasting.kt
@@ -29,6 +29,8 @@ import io.github.qauxv.base.annotation.FunctionHookEntry
 import io.github.qauxv.base.annotation.UiItemAgentEntry
 import io.github.qauxv.dsl.FunctionEntryRouter
 import io.github.qauxv.util.LicenseStatus
+import io.github.qauxv.util.QQVersion
+import io.github.qauxv.util.requireMinQQVersion
 import me.ketal.base.PluginDelayableHook
 import me.ketal.util.findClass
 import me.ketal.util.hookMethod
@@ -41,13 +43,14 @@ object TroopFileSaveLasting : PluginDelayableHook("ketal_TroopFileSaveLasting") 
     override val preference = uiSwitchPreference {
         title = "群文件长按转存永久"
     }
-    override val pluginID = "troop_plugin.apk"
+    override val pluginID = if (requireMinQQVersion(QQVersion.QQ_9_1_50)) "" else "troop_plugin.apk"
     override val uiItemLocation = FunctionEntryRouter.Locations.Auxiliary.FILE_CATEGORY
 
     override fun startHook(classLoader: ClassLoader) = throwOrTrue {
-        val troopFileShowAdapter = try {
-            "com.tencent.mobileqq.troop.data.TroopFileShowAdapter\$1"
-                .findClass(classLoader).getDeclaredField("this$0").type
+        val troopFileShowAdapter = try { (
+            if (requireMinQQVersion(QQVersion.QQ_9_1_50)) "com.tencent.mobileqq.troop.file.data.TroopFileShowAdapter$1"
+            else "com.tencent.mobileqq.troop.data.TroopFileShowAdapter$1"
+            ).findClass(classLoader).getDeclaredField("this$0").type
         } catch (e: Throwable) {
             "com.tencent.mobileqq.troop.data.TroopFileShowAdapter".findClass(classLoader)
         }

--- a/app/src/main/java/cc/ioctl/hook/ui/main/HideMiniAppPullEntry.kt
+++ b/app/src/main/java/cc/ioctl/hook/ui/main/HideMiniAppPullEntry.kt
@@ -89,7 +89,7 @@ object HideMiniAppPullEntry : CommonSwitchFunctionHook(ConfigItems.qn_hide_msg_l
                 // Lcom/scwang/smart/refresh/header/TwoLevelHeader;
                 // com.qqnt.widget.smartrefreshlayout.header.TwoLevelHeader
                 it.thisObject.javaClass.superclass.superclass.superclass.declaredFields.first {
-                    it.name == "D"  //mEnableTwoLevel
+                    it.name == (if (requireMinQQVersion(QQVersion.QQ_9_1_50)) "E" else "D") // mEnableTwoLevel
                 }.apply { isAccessible = true }.set(it.thisObject, false)
             }
 //            val name0 = when {

--- a/app/src/main/java/cc/ioctl/hook/ui/title/RemoveDailySign.kt
+++ b/app/src/main/java/cc/ioctl/hook/ui/title/RemoveDailySign.kt
@@ -56,12 +56,13 @@ object RemoveDailySign : CommonSwitchFunctionHook("kr_remove_daily_sign") {
         val callback = HookUtils.afterIfEnabled(this) { param ->
             // em_drawer_sign_up
             val dailySignName = when {
-                requireMinQQVersion(QQVersion.QQ_9_1_30) -> "c0"//9.1.30
-                requireMinQQVersion(QQVersion.QQ_9_0_90) -> "b0"//9.0.90~9.1.25
-                requireMinQQVersion(QQVersion.QQ_9_0_85) -> "d0"//9.0.85
-                requireMinQQVersion(QQVersion.QQ_9_0_35) -> "c0"//9.0.35~9.0.81
-                requireMinQQVersion(QQVersion.QQ_9_0_20) -> "a0"//9.0.20~9.0.30
-                requireMinQQVersion(QQVersion.QQ_9_0_0) -> "b0"//9.0.0~9.0.17
+                requireMinQQVersion(QQVersion.QQ_9_1_50) -> "g0" // 9.1.50
+                requireMinQQVersion(QQVersion.QQ_9_1_30) -> "c0" // 9.1.30 ~ 9.1.35
+                requireMinQQVersion(QQVersion.QQ_9_0_90) -> "b0" // 9.0.90 ~ 9.1.25
+                requireMinQQVersion(QQVersion.QQ_9_0_85) -> "d0" // 9.0.85
+                requireMinQQVersion(QQVersion.QQ_9_0_35) -> "c0" // 9.0.35 ~ 9.0.81
+                requireMinQQVersion(QQVersion.QQ_9_0_20) -> "a0" // 9.0.20 ~ 9.0.30
+                requireMinQQVersion(QQVersion.QQ_9_0_0) -> "b0"  // 9.0.0 ~ 9.0.17
                 requireMinQQVersion(QQVersion.QQ_8_9_90) -> "e0"
                 requireMinQQVersion(QQVersion.QQ_8_9_88) -> "h0"
                 requireMinQQVersion(QQVersion.QQ_8_9_70) -> "h0"

--- a/app/src/main/java/com/alphi/qhmk/module/HookUpgrade.java
+++ b/app/src/main/java/com/alphi/qhmk/module/HookUpgrade.java
@@ -61,6 +61,8 @@ public class HookUpgrade extends CommonSwitchFunctionHook {
         Class<?> upgc;
         upgc = Initiator.load("com.tencent.mobileqq.upgrade.UpgradeController");
         if (upgc == null)
+            upgc = Initiator.load("com.tencent.mobileqq.upgrade.k");
+        if (upgc == null)
             upgc = Initiator.load("com.tencent.mobileqq.app.upgrade.UpgradeController");
         if (upgc == null && HostInfo.requireRangePlayQQVersion(PlayQQVersion.PlayQQ_8_2_11, PlayQQVersion.PlayQQ_8_2_11))
             upgc = Initiator.load("aksy");

--- a/app/src/main/java/me/hd/hook/HideMsgListGuild.kt
+++ b/app/src/main/java/me/hd/hook/HideMsgListGuild.kt
@@ -44,7 +44,9 @@ object HideMsgListGuild : CommonSwitchFunctionHook() {
     override val isAvailable = requireMinQQVersion(QQVersion.QQ_8_9_88)
 
     override fun initOnce(): Boolean {
-        val bindingClass = Initiator.loadClass("com.tencent.qqnt.chats.f.a.e")
+        val bindingClass = Initiator.loadClass(
+            if (requireMinQQVersion(QQVersion.QQ_9_1_50)) "qu2.e" else "com.tencent.qqnt.chats.f.a.e"
+        )
         XposedBridge.hookAllConstructors(
             bindingClass,
             object : XC_MethodHook() {


### PR DESCRIPTION
# 标题 / Title Here

Fix Something on QQ 9.1.50+

## 描述 / Description

Fixed HideMiniAppPullEntry, TroopFileSaveLasting, HideMsgListGuild, HookUpgrade and RemoveDailySign on QQ 9.1.50 or higher.

## 修复或解决的问题 / Issues Fixed or Closed by This PR

TroopFileSaveLasting, HideMsgListGuild, HookUpgrade and RemoveDailySign unavailable
HideMiniAppPullEntry don't eliminate the white screen

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
