### PR TITLE
feat: HideLoadingDialog on QQ 9.1.50+

### DIFF
--- a/app/src/main/java/io/github/nakixii/hook/HideLoadingDialog.kt
+++ b/app/src/main/java/io/github/nakixii/hook/HideLoadingDialog.kt
@@ -1,0 +1,55 @@
+/*
+ * QAuxiliary - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2025 QAuxiliary developers
+ * https://github.com/cinit/QAuxiliary
+ *
+ * This software is an opensource software: you can redistribute it
+ * and/or modify it under the terms of the General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version as published
+ * by QAuxiliary contributors.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the General Public License for more details.
+ *
+ * You should have received a copy of the General Public License
+ * along with this software.
+ * If not, see
+ * <https://github.com/cinit/QAuxiliary/blob/master/LICENSE.md>.
+ */
+
+package io.github.nakixii.hook
+
+import cc.ioctl.util.hookBeforeIfEnabled
+import io.github.qauxv.base.annotation.FunctionHookEntry
+import io.github.qauxv.base.annotation.UiItemAgentEntry
+import io.github.qauxv.dsl.FunctionEntryRouter
+import io.github.qauxv.hook.CommonSwitchFunctionHook
+import io.github.qauxv.util.Initiator
+import io.github.qauxv.util.QQVersion
+import io.github.qauxv.util.requireMinVersion
+import xyz.nextalone.util.isPrivate
+
+@FunctionHookEntry
+@UiItemAgentEntry
+object HideLoadingDialog : CommonSwitchFunctionHook() {
+    override val name = "隐藏加载中对话框"
+    override val description = "隐藏有时出现的「加载中，请稍候…」对话框"
+    override val uiItemLocation = FunctionEntryRouter.Locations.Simplify.CHAT_OTHER
+    override val isAvailable = requireMinVersion(QQVersion.QQ_9_1_50)
+
+    override fun initOnce(): Boolean {
+        val troopAppsClass = Initiator.loadClass("com.tencent.mobileqq.troop.appscenter.mvi.TroopAppsViewModel")
+        val loadTroopMethod = troopAppsClass.declaredMethods.single { method ->
+            val params = method.parameterTypes
+            method.isPrivate && params.size == 3 && params[1] == Boolean::class.java
+        }
+
+        hookBeforeIfEnabled(loadTroopMethod) { param ->
+            param.args[1] = false
+        }
+        return true
+    }
+}


### PR DESCRIPTION
# feat: HideLoadingDialog on QQ 9.1.50+

## 描述 / Description

Add a function to hide the loading dialog on QQ 9.1.50+.

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
