### PR TITLE
Fix ChangeGroupStatus on QQ 9.1.50+

### DIFF
--- a/app/src/main/java/me/hd/hook/ChangeGroupStatus.kt
+++ b/app/src/main/java/me/hd/hook/ChangeGroupStatus.kt
@@ -47,7 +47,11 @@ object ChangeGroupStatus : CommonSwitchFunctionHook() {
     override val isAvailable = requireMinQQVersion(QQVersion.QQ_8_9_88)
 
     override fun initOnce(): Boolean {
-        if (requireMinQQVersion(QQVersion.QQ_9_0_8)) {
+        if (requireMinQQVersion(QQVersion.QQ_9_1_50)) {
+            "Lcom/tencent/mobileqq/data/troop/TroopInfo;->isUnreadableBlock()Z".method.hookBefore {
+                it.result = false
+            }
+        } else if (requireMinQQVersion(QQVersion.QQ_9_0_8)) {
             "Lcom/tencent/qqnt/aio/helper/TroopBlockHelper\$groupListener\$1;->a(Ljava/util/List;)V".method.hookBefore {
                 val list = it.args[0] as List<*>
                 list.forEach { troopInfo -> XposedHelpers.setBooleanField(troopInfo, "isTroopBlocked", false) }


### PR DESCRIPTION
# Fix ChangeGroupStatus on QQ 9.1.50+

## 描述 / Description

Fix ChangeGroupStatus on QQ 9.1.50+

## 修复或解决的问题 / Issues Fixed or Closed by This PR

ChangeGroupStatus is unavailable on QQ 9.1.50.

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
