### PR TITLE
fix: PttForward not work on 9.1.50+

### DIFF
--- a/app/src/main/java/cc/ioctl/hook/msg/PttForwardHook.java
+++ b/app/src/main/java/cc/ioctl/hook/msg/PttForwardHook.java
@@ -94,6 +94,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import kotlin.Unit;
+import nep.timeline.MessageUtils;
 
 @FunctionHookEntry
 @UiItemAgentEntry
@@ -362,6 +363,9 @@ public class PttForwardHook extends CommonSwitchFunctionHook implements OnMenuBu
                 dialog.setPositiveButton("发送", (dialog1, which) -> {
                     try {
                         for (ContactDescriptor cd : mTargets) {
+                            if (MessageUtils.sendVoice(path, cd))
+                                continue;
+
                             Parcelable sesssion = SessionInfoImpl.createSessionInfo(cd.uin, cd.uinType);
                             ChatActivityFacade.sendPttMessage(getQQAppInterface(), sesssion, path);
                         }

--- a/app/src/main/java/nep/timeline/MessageUtils.java
+++ b/app/src/main/java/nep/timeline/MessageUtils.java
@@ -1,0 +1,79 @@
+/*
+ * QAuxiliary - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2025 QAuxiliary developers
+ * https://github.com/cinit/QAuxiliary
+ *
+ * This software is an opensource software: you can redistribute it
+ * and/or modify it under the terms of the General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version as published
+ * by QAuxiliary contributors.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the General Public License for more details.
+ *
+ * You should have received a copy of the General Public License
+ * along with this software.
+ * If not, see
+ * <https://github.com/cinit/QAuxiliary/blob/master/LICENSE.md>.
+ */
+
+package nep.timeline;
+
+import android.media.MediaMetadataRetriever;
+import androidx.annotation.NonNull;
+import io.github.qauxv.util.Initiator;
+import io.github.qauxv.util.Log;
+import io.github.qauxv.util.data.ContactDescriptor;
+import io.github.qauxv.util.xpcompat.XposedBridge;
+import io.github.qauxv.util.xpcompat.XposedHelpers;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class MessageUtils {
+    private static long getDuration(@NonNull String pttPath) {
+        Objects.requireNonNull(pttPath, "pttPath == null");
+        long duration = 0;
+        try (MediaMetadataRetriever mmr = new MediaMetadataRetriever()) {
+            mmr.setDataSource(pttPath);
+            String time = mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
+            if (time != null)
+                duration = Long.parseLong(time);
+        } catch (Exception ignored) {
+        }
+        return duration;
+    }
+
+    public static Object api(Class<?> clazz) throws ClassNotFoundException {
+        Class<?> route = Initiator.loadClass("com.tencent.mobileqq.qroute.QRoute");
+        return XposedHelpers.callStaticMethod(route, "api", new Class[] { Class.class }, clazz);
+    }
+
+    public static boolean sendVoice(@NonNull String pttPath, @NonNull ContactDescriptor descriptor) {
+        try {
+            Object msgUtilApi = api(Initiator.loadClass("com.tencent.qqnt.msg.api.IMsgUtilApi"));
+            Object msgService = api(Initiator.loadClass("com.tencent.qqnt.msg.api.IMsgService"));
+
+            Object uinAndUidApi = api(Initiator.loadClass("com.tencent.relation.common.api.IRelationNTUinAndUidApi"));
+            String uid = (String) XposedHelpers.callMethod(uinAndUidApi, "getUidFromUin", descriptor.uin);
+            Object contact = XposedHelpers.newInstance(Initiator.loadClass("com.tencent.qqnt.kernelpublic.nativeinterface.Contact"), descriptor.uin + 1, uid, "");
+
+            Object callbackProxy = Proxy.newProxyInstance(Initiator.getHostClassLoader(), new Class[] { Initiator.loadClass("com.tencent.qqnt.kernel.nativeinterface.IOperateCallback") }, (proxy, method, methodArgs) -> null);
+            ArrayList<Object> arrayList = new ArrayList<>();
+            arrayList.add(XposedHelpers.callMethod(msgUtilApi, "createPttElement", pttPath, (int) getDuration(pttPath), new ArrayList<>(Arrays.asList(new Byte[] { 28, 26, 43, 29, 31, 61, 34, 49, 51, 56, 52, 74, 41, 62, 66, 46, 25, 57, 51, 70, 33, 45, 39, 27, 68, 58, 46, 59, 59, 63 }))));
+
+            XposedHelpers.callMethod(msgService, "sendMsg", contact, arrayList, callbackProxy);
+            return true;
+        } catch (ClassNotFoundException | NoSuchMethodError throwable) {
+            return false;
+        } catch (Throwable throwable) {
+            Log.e(throwable.toString(), throwable);
+            XposedBridge.log(throwable);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
# Fix PttForward on QQ 9.1.50+

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description

Fix feat issue

## 修复或解决的问题 / Issues Fixed or Closed by This PR

Fixed the issue where the ptt forward prompt was successful but not sent

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
