### PR TITLE
fix: sticker panel on QQ 9.1.70

### DIFF
--- a/app/src/main/java/cc/hicore/message/bridge/Nt_kernel_bridge.java
+++ b/app/src/main/java/cc/hicore/message/bridge/Nt_kernel_bridge.java
@@ -71,8 +71,12 @@ public class Nt_kernel_bridge {
     }
 
     public static MsgAttributeInfo getDefaultAttributeInfo() {
-
-        VASMsgNamePlate plate = new VASMsgNamePlate(258, 64, 0, 0, 0, 0, 258, 0, new ArrayList<>(), 0, 0);
+        VASMsgNamePlate plate;
+        if (requireMinQQVersion(QQVersion.QQ_9_1_70)) {
+            plate = new VASMsgNamePlate(258, 64, 0, 0, 0, 0, 258, 0, new ArrayList<>(), 0, 0, 0);
+        } else {
+            plate = new VASMsgNamePlate(258, 64, 0, 0, 0, 0, 258, 0, new ArrayList<>(), 0, 0);
+        }
         VASMsgBubble bubble = new VASMsgBubble(0, 0, 0, 0);
         VASMsgFont font = new VASMsgFont(65536, 0L, 0, 0, 0);
         VASMsgAvatarPendant pendant = new VASMsgAvatarPendant();


### PR DESCRIPTION
# 标题 / Title Here
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
修复表情面板在QQ 9.1.70 上发送图片时崩溃的问题

## 描述 / Description

<!--- Describe your changes in detail here. -->
QQ 貌似在 9.1.70 更新了VASMsgNamePlate，旧的代码会引发 NoSuchMethodError

## 修复或解决的问题 / Issues Fixed or Closed by This PR
#1386

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
