### PR TITLE
fix: PttForward cannot be forwarded to the group

### DIFF
--- a/app/src/main/java/nep/timeline/MessageUtils.java
+++ b/app/src/main/java/nep/timeline/MessageUtils.java
@@ -66,7 +66,9 @@ public class MessageUtils {
             Object msgService = api(Initiator.loadClass("com.tencent.qqnt.msg.api.IMsgService"));
 
             Object uinAndUidApi = api(Initiator.loadClass("com.tencent.relation.common.api.IRelationNTUinAndUidApi"));
-            String uid = (String) XposedHelpers.callMethod(uinAndUidApi, "getUidFromUin", descriptor.uin);
+            int type = descriptor.uinType + 1;
+            String uin = descriptor.uin;
+            String uid = (type != 2 && type != 4 && uin.chars().allMatch(Character::isDigit)) ? (String) XposedHelpers.callMethod(uinAndUidApi, "getUidFromUin", uin) : uin;
 
             Class<?> contactClass;
             if (kernelPublic) {
@@ -80,7 +82,7 @@ public class MessageUtils {
                 }
             }
 
-            Object contact = XposedHelpers.newInstance(contactClass, descriptor.uinType + 1, uid, "");
+            Object contact = XposedHelpers.newInstance(contactClass, type, uid, "");
 
             Object callbackProxy = Proxy.newProxyInstance(Initiator.getHostClassLoader(), new Class[] { Initiator.loadClass("com.tencent.qqnt.kernel.nativeinterface.IOperateCallback") }, (proxy, method, methodArgs) -> null);
             ArrayList<Object> arrayList = new ArrayList<>();


### PR DESCRIPTION
# Fix PttForward cannot be forwarded to the group on QQ 9.0.8+

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description

Fix feat issue

## 修复或解决的问题 / Issues Fixed or Closed by This PR

Fixed the issue where the ptt forward prompt was successful but not sent

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
