### PR TITLE
fix: 9.1.75 Stick Plate Error

### DIFF
--- a/app/src/main/java/cc/hicore/message/bridge/Nt_kernel_bridge.java
+++ b/app/src/main/java/cc/hicore/message/bridge/Nt_kernel_bridge.java
@@ -72,7 +72,7 @@ public class Nt_kernel_bridge {
 
     public static MsgAttributeInfo getDefaultAttributeInfo() {
 
-        VASMsgNamePlate plate = new VASMsgNamePlate(258, 64, 0, 0, 0, 0, 258, 0, new ArrayList<>(), 0, 0,0);
+        VASMsgNamePlate plate = new VASMsgNamePlate(258, 64, 0, 0, 0, 0, 258, 0, new ArrayList<>(), 0, 0, 0);
         VASMsgBubble bubble = new VASMsgBubble(0, 0, 0, 0);
         VASMsgFont font = new VASMsgFont(65536, 0L, 0, 0, 0);
         VASMsgAvatarPendant pendant = new VASMsgAvatarPendant();

--- a/app/src/main/java/cc/hicore/message/bridge/Nt_kernel_bridge.java
+++ b/app/src/main/java/cc/hicore/message/bridge/Nt_kernel_bridge.java
@@ -72,7 +72,7 @@ public class Nt_kernel_bridge {
 
     public static MsgAttributeInfo getDefaultAttributeInfo() {
 
-        VASMsgNamePlate plate = new VASMsgNamePlate(258, 64, 0, 0, 0, 0, 258, 0, new ArrayList<>(), 0, 0);
+        VASMsgNamePlate plate = new VASMsgNamePlate(258, 64, 0, 0, 0, 0, 258, 0, new ArrayList<>(), 0, 0,0);
         VASMsgBubble bubble = new VASMsgBubble(0, 0, 0, 0);
         VASMsgFont font = new VASMsgFont(65536, 0L, 0, 0, 0);
         VASMsgAvatarPendant pendant = new VASMsgAvatarPendant();

--- a/app/src/main/java/cc/hicore/message/chat/SessionUtils.java
+++ b/app/src/main/java/cc/hicore/message/chat/SessionUtils.java
@@ -21,7 +21,8 @@
 
 package cc.hicore.message.chat;
 
-import static cc.ioctl.util.HostInfo.requireMinTimVersion;
+
+import static cc.ioctl.util.HostInfo.requireStickPlantVersion;
 
 import cc.hicore.ReflectUtil.XField;
 import cc.hicore.Utils.XLog;
@@ -57,14 +58,14 @@ public class SessionUtils {
     }
 
     public static String getCurrentPeerIDByAIOContact(Object AIOContact) throws Exception {
-        return XField.obj(AIOContact).name(requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) ? "e" : "f").type(String.class).get();
+        return XField.obj(AIOContact).name(requireStickPlantVersion(TIMVersion.TIM_4_0_95_BETA) ? "e" : "f").type(String.class).get();
     }
 
     public static int getCurrentChatTypeByAIOContact(Object AIOContact) throws Exception {
-        return XField.obj(AIOContact).name(requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) ? "d" : "e").type(int.class).get();
+        return XField.obj(AIOContact).name(requireStickPlantVersion(TIMVersion.TIM_4_0_95_BETA) ? "d" : "e").type(int.class).get();
     }
 
     public static String getCurrentGuildIDByAIOContact(Object AIOContact) throws Exception {
-        return XField.obj(AIOContact).name(requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) ? "f" : "g").type(String.class).get();
+        return XField.obj(AIOContact).name(requireStickPlantVersion(TIMVersion.TIM_4_0_95_BETA) ? "f" : "g").type(String.class).get();
     }
 }

--- a/app/src/main/java/cc/ioctl/util/HostInfo.java
+++ b/app/src/main/java/cc/ioctl/util/HostInfo.java
@@ -23,6 +23,7 @@ package cc.ioctl.util;
 
 import android.app.Application;
 import androidx.annotation.NonNull;
+import io.github.qauxv.util.QQVersion;
 
 /**
  * Helper class for getting host information. Keep it as simple as possible.
@@ -115,5 +116,9 @@ public class HostInfo {
 
     public static boolean requireMinTimVersion(long versionCode) {
         return isTim() && getLongVersionCode() >= versionCode;
+    }
+
+    public static boolean requireStickPlantVersion(long versionCode) {
+        return requireMinTimVersion(versionCode) ||  requireMinQQVersion(QQVersion.QQ_9_1_75);
     }
 }

--- a/app/src/main/java/io/github/qauxv/util/QQVersion.java
+++ b/app/src/main/java/io/github/qauxv/util/QQVersion.java
@@ -184,4 +184,5 @@ public class QQVersion {
     public static final long QQ_9_1_60 = 9388;
     public static final long QQ_9_1_65_BETA_24705 = 9522;
     public static final long QQ_9_1_65 = 9558;
+    public static final long QQ_9_1_75 = 10068;
 }


### PR DESCRIPTION
# 标题 / Title Here

修复QQ9.1.75版本表情面板闪退问题

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description

修复https://github.com/cinit/QAuxiliary/issues/1409

仅进行了有限的测试(在Android14,QQ 9.1.75,LSPOSED 1.9.2表情面板能够正常使用)

<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR

https://github.com/cinit/QAuxiliary/issues/1409

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [✔] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [✔] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [✔] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
