### PR TITLE
fix: SimplifyQQSettingMe

### DIFF
--- a/app/src/main/java/io/github/horange321/SimplifyQQSettingMe2.kt
+++ b/app/src/main/java/io/github/horange321/SimplifyQQSettingMe2.kt
@@ -1,0 +1,113 @@
+/*
+ * QAuxiliary - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2025 QAuxiliary developers
+ * https://github.com/cinit/QAuxiliary
+ *
+ * This software is an opensource software: you can redistribute it
+ * and/or modify it under the terms of the General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version as published
+ * by QAuxiliary contributors.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the General Public License for more details.
+ *
+ * You should have received a copy of the General Public License
+ * along with this software.
+ * If not, see
+ * <https://github.com/cinit/QAuxiliary/blob/master/LICENSE.md>.
+ */
+
+package io.github.horange321
+
+import com.github.kyuubiran.ezxhelper.utils.field
+import com.github.kyuubiran.ezxhelper.utils.findField
+import com.github.kyuubiran.ezxhelper.utils.hookAfter
+import io.github.qauxv.base.annotation.FunctionHookEntry
+import io.github.qauxv.base.annotation.UiItemAgentEntry
+import io.github.qauxv.dsl.FunctionEntryRouter.Locations.Simplify
+import io.github.qauxv.util.Initiator.loadClass
+import xyz.nextalone.base.MultiItemDelayableHook
+import xyz.nextalone.util.method
+
+
+@FunctionHookEntry
+@UiItemAgentEntry
+object SimplifyQQSettingMe2 : MultiItemDelayableHook(
+    "SimplifyQQSettingMe2"
+) {
+    val map = hashMapOf(
+        "d_album" to "相册",
+        "d_favorite" to "收藏",
+        "d_document" to "文件",
+        "d_qqwallet" to "钱包",
+        "d_vip_identity" to "会员中心",
+        "d_decoration" to "个性装扮",
+        "d_vip_card" to "免流量"
+    )
+    override val preferenceTitle = "新版侧滑栏精简"
+    override val allItems = map.values.toSet()
+    override val uiItemLocation = Simplify.SLIDING_UI
+
+
+    private fun needRemove(bean: Any): Boolean {
+        bean::class.java.declaredFields.forEach { f ->
+            if (f.type == java.lang.String::class.java) {
+                f.isAccessible = true
+                if (map[f.get(bean)!! as String] in activeItems) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+
+    override fun initOnce(): Boolean {
+        val clazz = loadClass("com.tencent.mobileqq.parts.QQSettingMeMenuPanelPartV3")
+        clazz.method("onInitView")!!.hookAfter {
+            val obj = it.thisObject
+//ArrayList<com.tencent.mobileqq.adapter.u> com.tencent.mobileqq.parts.QQSettingMeMenuPanelPartV3$bizData
+            val bizDataList = clazz.findField {
+                type == java.util.ArrayList::class.java
+            }.run {
+                isAccessible = true
+                get(obj)!! as ArrayList<Any>
+            }
+
+            // 删掉要去掉的东西
+            val i = bizDataList.iterator()
+            while (i.hasNext()) {
+                val v = i.next()
+//com.tencent.mobileqq.activity.qqsettingme.config.QQSettingMeBizBean com.tencent.mobileqq.adapter.u:bean
+                // 是唯一的 field，可以直接 hardcode
+                val bean = v.field("a").run {
+                    isAccessible = true
+                    get(v)
+                }
+                // 有的会有 null 出现。需要特殊处理
+                if (bean == null) continue
+                if (needRemove(bean))
+                    i.remove()
+            }
+
+//com.tencent.mobileqq.adapter.t com.tencent.mobileqq.parts.QQSettingMeMenuPanelPartV3$listItemAdapter
+            val listItemAdapter = clazz.findField {
+                type.name.contains("adapter")
+            }.run {
+                isAccessible = true
+                get(obj)!!
+            }
+
+            // set adapter items
+            loadClass("com.tencent.biz.richframework.part.adapter.AsyncListDifferDelegationAdapter")
+                .method("setItems")!!.run {
+                    isAccessible = true
+                    invoke(listItemAdapter, bizDataList)
+                }
+        }
+        return true
+    }
+}


### PR DESCRIPTION
# 标题 / Title Here
侧滑栏精简

## 描述 / Description
新版QQ更改了侧滑栏，所以以前的`侧滑栏精简`功能失效了。

## 修复或解决的问题 / Issues Fixed or Closed by This PR
侧滑栏精简

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [X] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [X] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [X] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)

## 特别说明
1.  我不知道是哪一个版本起改的侧滑栏，手里也没有旧版QQ用与测试。所以没有加上版本条件限制。
2. 为了保留旧版支持，在设置页面单开了一个选项，而不是改原有的代码。至于区分不同版本不同写法，原因见第一条。如果知道了版本最好将两个设置合并。
3. 不知道怎么缓存 `findField` 结果