### PR TITLE
fix: ChatItemShowQQUin is invalid after PromptForNoSeqMessage is enabled

### DIFF
--- a/app/src/main/java/me/ketal/hook/ChatItemShowQQUin.kt
+++ b/app/src/main/java/me/ketal/hook/ChatItemShowQQUin.kt
@@ -75,6 +75,7 @@ import io.github.qauxv.util.Toasts
 import io.github.qauxv.util.requireMinQQVersion
 import io.github.qauxv.util.requireMinTimVersion
 import io.github.qauxv.util.xpcompat.XC_MethodHook
+import nep.timeline.PromptForNoSeqMessage
 import kotlinx.coroutines.flow.MutableStateFlow
 import me.ketal.dispacher.BaseBubbleBuilderHook
 import me.ketal.dispacher.OnBubbleBuilder
@@ -369,7 +370,12 @@ object ChatItemShowQQUin : CommonConfigFunctionHook(), OnBubbleBuilder {
     override fun onGetViewNt(rootView: ViewGroup, chatMessage: MsgRecord, param: XC_MethodHook.MethodHookParam) {
         // 因为tailMessage是自己添加的，所以闪照文字也放这里处理
         val isFlashPicTagNeedShow = FlashPicHook.INSTANCE.isInitializationSuccessful && isFlashPicNt(chatMessage)
-        if (!isEnabled && !isFlashPicTagNeedShow) return
+        val isNoSeqMessage = PromptForNoSeqMessage.isEnabled && PromptForNoSeqMessage.shouldShowTailMsgForMsgRecord(chatMessage)
+        if (isNoSeqMessage)
+            return
+
+        if (!isEnabled && !isFlashPicTagNeedShow)
+            return
 
         if (requireMinQQVersion(QQVersion.QQ_8_9_63_BETA_11345) || requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA)) {
             if (!rootView.children.map { it.id }.contains(ID_ADD_LAYOUT)) {

--- a/app/src/main/java/nep/timeline/PromptForNoSeqMessage.kt
+++ b/app/src/main/java/nep/timeline/PromptForNoSeqMessage.kt
@@ -95,7 +95,7 @@ object PromptForNoSeqMessage : CommonSwitchFunctionHook(), OnBubbleBuilder {
     private val constraintSetClz by lazy { "androidx.constraintlayout.widget.ConstraintSet".clazz!! }
     private val constraintLayoutClz by lazy { "androidx.constraintlayout.widget.ConstraintLayout".clazz!! }
 
-    private fun shouldShowTailMsgForMsgRecord(chatMessage: MsgRecord): Boolean {
+    public fun shouldShowTailMsgForMsgRecord(chatMessage: MsgRecord): Boolean {
         // do not show tail message for grey tips
         return chatMessage.msgType != MsgConstants.MSG_TYPE_GRAY_TIPS && MessageUtils.isNoSeqMessage(chatMessage.sendStatus)
     }
@@ -106,7 +106,7 @@ object PromptForNoSeqMessage : CommonSwitchFunctionHook(), OnBubbleBuilder {
 
     @SuppressLint("ResourceType", "SetTextI18n")
     override fun onGetViewNt(rootView: ViewGroup, chatMessage: MsgRecord, param: XC_MethodHook.MethodHookParam) {
-        if (!isEnabled) return
+        if (!isEnabled || !shouldShowTailMsgForMsgRecord(chatMessage)) return
 
         if (requireMinQQVersion(QQVersion.QQ_8_9_63_BETA_11345) || requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA)) {
             if (!rootView.children.map { it.id }.contains(ID_ADD_LAYOUT)) {


### PR DESCRIPTION
# 标题 / Title Here

修复开启PromptForNoSeqMessage后ChatItemShowQQUin不工作的问题

## 描述 / Description

修复开启PromptForNoSeqMessage后因为冲突而导致ChatItemShowQQUin不工作

## 修复或解决的问题 / Issues Fixed or Closed by This PR

修复开启PromptForNoSeqMessage后ChatItemShowQQUin不工作的问题

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [X] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [X] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [X] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
