### PR TITLE
fix: StickerPanelEntryHooker on 9.2.27

### DIFF
--- a/app/src/main/java/io/github/qauxv/util/dexkit/DexKitTarget.kt
+++ b/app/src/main/java/io/github/qauxv/util/dexkit/DexKitTarget.kt
@@ -416,7 +416,7 @@ data object VasAttrBuilder : DexKitTarget.UsingStr() {
 
 data object Guild_Emo_Btn_Create_QQNT : DexKitTarget.UsingStr() {
     override val findMethod: Boolean = true
-    override val traitString = arrayOf("mEmojiLayout.findViewByI…id.guild_aio_emoji_image)")
+    override val traitString = arrayOf("mEmojiLayout")
     override val declaringClass = "Guild_Emo_Btn_Create_QQNT"
     override val filter = DexKitFilter.allowAll
 }
@@ -722,7 +722,7 @@ data object GroupSpecialCare_getCareTroopMemberMsgText : DexKitTarget.UsingStr()
 
 data object ChatPanel_InitPanel_QQNT : DexKitTarget.UsingStr() {
     override val findMethod: Boolean = true
-    override val traitString = arrayOf("funBtnLayout.findViewById(R.id.fun_btn)")
+    override val traitString = arrayOf("funBtnLayout.findViewById(R.id.fun_btn)", "updateFunBtn")
     override val declaringClass = "ChatPanel_InitPanel_QQNT"
     override val filter = DexKitFilter.allowAll
 }


### PR DESCRIPTION
# 标题 / Title Here

修复表情面板 Hook 位点

## 描述 / Description

修复表情面板的 DexKit Hook 位点

## 修复或解决的问题 / Issues Fixed or Closed by This PR

None

## 检查列表 / Check List

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- **Not tested yet.** 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。 
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
