### PR TITLE
fix: ReplyNoAtHook at 9.9.30

### DIFF
--- a/app/src/main/java/io/github/qauxv/util/dexkit/DexKitTarget.kt
+++ b/app/src/main/java/io/github/qauxv/util/dexkit/DexKitTarget.kt
@@ -763,6 +763,13 @@ data object Reply_At_QQNT : DexKitTarget.UsingStr() {
     override val filter = DexKitFilter.strInClsName("com/tencent/mobileqq/aio/input")
 }
 
+data object Reply_At_QQNT_9_0_30 : DexKitTarget.UsingStringVector() {
+    override val findMethod: Boolean = true
+    override val traitString = arrayOf("intent", "senderUid", "msgItem")
+    override val declaringClass = ""
+    override val filter = DexKitFilter.strInClsName("com/tencent/mobileqq/aio/input/reply")
+}
+
 data object TroopSendFile_QQNT : DexKitTarget.UsingStr() {
     override val findMethod: Boolean = true
     override val traitString = arrayOf("send local to troop file use nt, filePath:")


### PR DESCRIPTION
# 标题 / Title Here

修复禁用回复自动@功能，于 QQ 9.9.30

## 描述 / Description
小白对QA的构建和特有的hook语法不熟悉，只能结合反编译+核心破解来测试，提供的代码无法保证直接可用，劳烦开发者完善！具体思路是对MsgRecord设置一个AnonymousExtInfo，来规避自动@

## 修复或解决的问题 / Issues Fixed or Closed by This PR
ReplyNoAt for 9.9.30

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [1 ] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [ 1] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [ 1] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
