### PR TITLE
feat: PermissionMaskingHook

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -25,6 +25,7 @@
 -keep class wang.allenyou.** { *; }
 -keep class im.mingxi.** { *; }
 -keep class io.github.relimus.** { *; }
+-keep class com.likejson.** { *; }
 
 -keepclasseswithmembernames class * {
     native <methods>;

--- a/app/src/main/java/com/likejson/hook/PermissionMaskingHook.kt
+++ b/app/src/main/java/com/likejson/hook/PermissionMaskingHook.kt
@@ -1,0 +1,47 @@
+package com.likejson.hook
+
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import io.github.qauxv.base.annotation.FunctionHookEntry
+import io.github.qauxv.base.annotation.UiItemAgentEntry
+import io.github.qauxv.dsl.FunctionEntryRouter
+import io.github.qauxv.hook.CommonSwitchFunctionHook
+import io.github.qauxv.util.xpcompat.XC_MethodHook
+import io.github.qauxv.util.xpcompat.XposedHelpers
+import java.util.Arrays
+
+@FunctionHookEntry
+@UiItemAgentEntry
+object PermissionMaskingHook : CommonSwitchFunctionHook() {
+    override val name = "伪装权限"
+    override val description = "让QQ认为自己获取了所有权限\n配合 使用系统相册/文件 使用"
+    override val uiItemLocation: Array<String> = FunctionEntryRouter.Locations.Auxiliary.EXPERIMENTAL_CATEGORY
+    override fun initOnce(): Boolean {
+        // beforeHookIfEnabled 会报 NoSuchMethod 拼尽全力无法战胜，反正现在代码能跑（）
+        XposedHelpers.findAndHookMethod(
+            Activity::class.java,
+            "onRequestPermissionsResult",
+            Int::class.javaPrimitiveType,
+            Array<String>::class.java,
+            IntArray::class.java,
+            object : XC_MethodHook() {
+                @Throws(Throwable::class)
+                protected override fun beforeHookedMethod(param: MethodHookParam) {
+                    val permissions = param.args[1] as Array<String?>
+                    val grantResults = param.args[2] as IntArray
+                    for (i in permissions.indices) {
+                        grantResults[i] = PackageManager.PERMISSION_GRANTED
+                    }
+                    val modifiedResults = IntArray(grantResults.size)
+                    Arrays.fill(modifiedResults, PackageManager.PERMISSION_GRANTED)
+                    param.args[2] = modifiedResults
+                }
+            }
+        )
+        return true
+    }
+
+}
+
+


### PR DESCRIPTION
# 假装授予权限

## 描述 / Description
修改onRequestPermissionsResult，始终返回PackageManager.PERMISSION_GRANTED
## 修复或解决的问题 / Issues Fixed or Closed by This PR
解决ForceSystemAlbum任然需要授予存储权限才能打开的问题
## 检查列表 / Check List
- [X] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [X] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [X] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
