### PR TITLE
feat(ForceSystemAlbum): Allow setting a default album type

### DIFF
--- a/app/src/main/java/me/singleneuron/hook/decorator/ForceSystemAlbum.kt
+++ b/app/src/main/java/me/singleneuron/hook/decorator/ForceSystemAlbum.kt
@@ -83,14 +83,18 @@ object ForceSystemAlbum : BaseDecorator(
             override val switchProvider = null
             override val onClickListener: ((IUiItemAgent, Activity, View) -> Unit) = { _, activity, _ ->
                 val currentType = getCurrentAlbumType()
-                AlertDialog.Builder(activity).setTitle("选择默认相册类型").setSingleChoiceItems(albumTypes, currentType) { dialog, which ->
-                    setAlbumType(which)
-                    isEnabled = true
-                    dialog.dismiss()
-                }.setNegativeButton(android.R.string.cancel, null).setNeutralButton("禁用") { _, _ ->
-                    isEnabled = false
-                    _valueState.value = null
-                }.show()
+                AlertDialog.Builder(activity)
+                    .setTitle("选择默认相册类型")
+                    .setSingleChoiceItems(albumTypes, currentType) { dialog, which ->
+                        setAlbumType(which)
+                        isEnabled = true
+                        dialog.dismiss()
+                    }
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .setNeutralButton("禁用") { _, _ ->
+                        isEnabled = false
+                        _valueState.value = null
+                    }.show()
             }
             override val extraSearchKeywordProvider: ((IUiItemAgent, Context) -> Array<String>?)? = null
         }
@@ -101,9 +105,9 @@ object ForceSystemAlbum : BaseDecorator(
 
         val isWinkHomeActivity = intent.component?.className?.contains("WinkHomeActivity") == true
         val isNewPhotoListActivity = intent.component?.className?.contains("NewPhotoListActivity") == true
-        if ((isWinkHomeActivity || (isNewPhotoListActivity && intent.getIntExtra(
-                "uintype", -1
-            ) != -1)) && (!intent.getBooleanExtra("PhotoConst.IS_CALL_IN_PLUGIN", false)) && (!intent.getBooleanExtra("is_decorated", false))
+        if ((isWinkHomeActivity || (isNewPhotoListActivity && intent.getIntExtra("uintype", -1) != -1))
+            && (!intent.getBooleanExtra("PhotoConst.IS_CALL_IN_PLUGIN", false))
+            && (!intent.getBooleanExtra("is_decorated", false))
         ) {
             val uin = intent.getStringExtra("uin")
             if (uin.toString().length > 10) {
@@ -159,23 +163,31 @@ object ForceSystemAlbum : BaseDecorator(
     }
 
     private fun showAlbumSelectionDialog(context: Context, intent: Intent, param: XC_MethodHook.MethodHookParam) {
-        val activityMap = mapOf("系统相册" to Intent(context, ChooseAgentActivity::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            putExtra("use_ACTION_PICK", true)
-            putExtras(intent)
-            type = "image/*"
-        }, "系统文档" to Intent(context, ChooseAgentActivity::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            putExtras(intent)
-            type = "image/*"
-        }, "QQ 相册" to intent.apply {
-            putExtra("is_decorated", true)
-        })
+        val activityMap = mapOf(
+            "系统相册" to Intent(context, ChooseAgentActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                putExtra("use_ACTION_PICK", true)
+                putExtras(intent)
+                type = "image/*"
+            },
+            "系统文档" to Intent(context, ChooseAgentActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                putExtras(intent)
+                type = "image/*"
+            },
+            "QQ 相册" to intent.apply {
+                putExtra("is_decorated", true)
+            }
+        )
 
         // 使用 AlertDialog 而不是 MaterialAlertDialogBuilder，因为 context 可能不是 Activity
-        AlertDialog.Builder(context).setTitle("选择相册").setItems(activityMap.keys.toTypedArray()) { _, i ->
-            context.startActivity(activityMap[activityMap.keys.toTypedArray()[i]])
-        }.create().show()
+        AlertDialog.Builder(context)
+            .setTitle("选择相册")
+            .setItems(activityMap.keys.toTypedArray()) { _, i ->
+                context.startActivity(activityMap[activityMap.keys.toTypedArray()[i]])
+            }
+            .create()
+            .show()
         param.result = null
     }
 }


### PR DESCRIPTION
# feat(可选使用系统相册): 支持设置默认相册类型

## 描述 / Description

将“可选使用系统相册”功能重构为可配置选项，而不再是简单的开关。

此前，该功能每次都会弹出选择对话框。本次更新后，用户可以设置一个默认行为，以改善重复操作的体验。

新增的默认选项包括：
- 每次询问（旧版行为）
- 系统相册
- 系统文档
- QQ 相册

此配置项已添加到模块设置界面，用户可在此处选择默认值或禁用该功能。

## 修复或解决的问题 / Issues Fixed or Closed by This PR

#1543 

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
