### PR TITLE
fix: ForcePadMode and ForcePhoneMode on QQ 9.2.65+

### DIFF
--- a/app/src/main/java/cc/ioctl/hook/experimental/ForcePadMode.kt
+++ b/app/src/main/java/cc/ioctl/hook/experimental/ForcePadMode.kt
@@ -60,16 +60,20 @@ object ForcePadMode : CommonSwitchFunctionHook(targetProc = SyncUtils.PROC_ANY) 
 //            Log.i("ForcePadMode getAppId: $result")
 //        }
         val appSettingClass = Initiator.loadClass("com.tencent.common.config.AppSetting")
-        appSettingClass.getDeclaredMethod("f").hookAfter {
+        appSettingClass.getDeclaredMethod(
+            if (requireMinQQVersion(QQVersion.QQ_9_2_30)) "e" else "f"
+        ).hookAfter {
             val (appIdPhone, appIdPad) = Pair(
                 when {
                     requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) -> "f"
+                    requireMinQQVersion(QQVersion.QQ_9_2_30) -> "f"
                     requireMinQQVersion(QQVersion.QQ_9_2_15) -> "g"
                     requireMinQQVersion(QQVersion.QQ_9_1_50) -> "f"
                     else -> "e"
                 },
                 when {
                     requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) -> "g"
+                    requireMinQQVersion(QQVersion.QQ_9_2_30) -> "g"
                     requireMinQQVersion(QQVersion.QQ_9_2_15) -> "h"
                     requireMinQQVersion(QQVersion.QQ_9_1_50) -> "g"
                     else -> "f"

--- a/app/src/main/java/cc/ioctl/hook/experimental/ForcePadMode.kt
+++ b/app/src/main/java/cc/ioctl/hook/experimental/ForcePadMode.kt
@@ -66,6 +66,7 @@ object ForcePadMode : CommonSwitchFunctionHook(targetProc = SyncUtils.PROC_ANY) 
             val (appIdPhone, appIdPad) = Pair(
                 when {
                     requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) -> "f"
+                    requireMinQQVersion(QQVersion.QQ_9_2_65) -> "e"
                     requireMinQQVersion(QQVersion.QQ_9_2_30) -> "f"
                     requireMinQQVersion(QQVersion.QQ_9_2_15) -> "g"
                     requireMinQQVersion(QQVersion.QQ_9_1_50) -> "f"
@@ -73,6 +74,7 @@ object ForcePadMode : CommonSwitchFunctionHook(targetProc = SyncUtils.PROC_ANY) 
                 },
                 when {
                     requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) -> "g"
+                    requireMinQQVersion(QQVersion.QQ_9_2_65) -> "f"
                     requireMinQQVersion(QQVersion.QQ_9_2_30) -> "g"
                     requireMinQQVersion(QQVersion.QQ_9_2_15) -> "h"
                     requireMinQQVersion(QQVersion.QQ_9_1_50) -> "g"

--- a/app/src/main/java/cc/ioctl/hook/experimental/ForcePhoneMode.kt
+++ b/app/src/main/java/cc/ioctl/hook/experimental/ForcePhoneMode.kt
@@ -50,16 +50,20 @@ object ForcePhoneMode : CommonSwitchFunctionHook(targetProc = SyncUtils.PROC_ANY
     override fun initOnce() = throwOrTrue {
         check(isAvailable) { "ForcePhoneMode is not available" }
         val appSettingClass = Initiator.loadClass("com.tencent.common.config.AppSetting")
-        appSettingClass.getDeclaredMethod("f").hookAfter {
+        appSettingClass.getDeclaredMethod(
+            if (requireMinQQVersion(QQVersion.QQ_9_2_30)) "e" else "f"
+        ).hookAfter {
             val (appIdPhone, appIdPad) = Pair(
                 when {
                     requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) -> "f"
+                    requireMinQQVersion(QQVersion.QQ_9_2_30) -> "f"
                     requireMinQQVersion(QQVersion.QQ_9_2_15) -> "g"
                     requireMinQQVersion(QQVersion.QQ_9_1_50) -> "f"
                     else -> "e"
                 },
                 when {
                     requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) -> "g"
+                    requireMinQQVersion(QQVersion.QQ_9_2_30) -> "g"
                     requireMinQQVersion(QQVersion.QQ_9_2_15) -> "h"
                     requireMinQQVersion(QQVersion.QQ_9_1_50) -> "g"
                     else -> "f"

--- a/app/src/main/java/cc/ioctl/hook/experimental/ForcePhoneMode.kt
+++ b/app/src/main/java/cc/ioctl/hook/experimental/ForcePhoneMode.kt
@@ -56,6 +56,7 @@ object ForcePhoneMode : CommonSwitchFunctionHook(targetProc = SyncUtils.PROC_ANY
             val (appIdPhone, appIdPad) = Pair(
                 when {
                     requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) -> "f"
+                    requireMinQQVersion(QQVersion.QQ_9_2_65) -> "e"
                     requireMinQQVersion(QQVersion.QQ_9_2_30) -> "f"
                     requireMinQQVersion(QQVersion.QQ_9_2_15) -> "g"
                     requireMinQQVersion(QQVersion.QQ_9_1_50) -> "f"
@@ -63,6 +64,7 @@ object ForcePhoneMode : CommonSwitchFunctionHook(targetProc = SyncUtils.PROC_ANY
                 },
                 when {
                     requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA) -> "g"
+                    requireMinQQVersion(QQVersion.QQ_9_2_65) -> "f"
                     requireMinQQVersion(QQVersion.QQ_9_2_30) -> "g"
                     requireMinQQVersion(QQVersion.QQ_9_2_15) -> "h"
                     requireMinQQVersion(QQVersion.QQ_9_1_50) -> "g"


### PR DESCRIPTION
# 标题 / Title Here

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description
<!--- Describe your changes in detail here. -->
QQ 9.2.30+ 和 9.2.65+ 获取appId的部分方法和字段有变化。
## 修复或解决的问题 / Issues Fixed or Closed by This PR
尝试适配了 QQ 9.2.30+ 和 9.2.65+ 获取appId中的部分方法和字段的变化。
## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
