### PR TITLE
fix: RepeaterPlus on QQ 9.2.30+

### DIFF
--- a/app/src/main/java/cc/hicore/hook/RepeaterPlus.java
+++ b/app/src/main/java/cc/hicore/hook/RepeaterPlus.java
@@ -179,7 +179,75 @@ public class RepeaterPlus extends BaseFunctionHook implements SessionHooker.IAIO
     @Override
     @SuppressLint({"WrongConstant", "ResourceType"})
     public boolean initOnce() throws Exception {
-        if (requireMinQQVersion(QQVersion.QQ_8_9_63_BETA_11345) || requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA)) {
+        if (requireMinQQVersion(QQVersion.QQ_9_2_30)) {
+            if (!RepeaterPlusIconSettingDialog.getIsShowInMenu()) {
+                XC_MethodHook callback = new XC_MethodHook() {
+                    private volatile long click_time = 0;
+
+                    @Override
+                    protected void afterHookedMethod(MethodHookParam param) throws Exception {
+                        if (param.args.length == 3
+                                && param.args[0] instanceof Integer
+                                && param.args[2] instanceof List
+                        ) {
+                            ImageView imageView = null;
+
+                            Object lazyInstance = XField.obj(param.thisObject)
+                                    .filter((field, value) -> {
+                                        String typeName = field.getType().getName();
+                                        return typeName.equals("kotlin.Lazy") || typeName.contains("Lazy");
+                                    })
+                                    .get();
+
+                            if (lazyInstance != null) {
+                                imageView = XMethod.obj(lazyInstance)
+                                        .name("getValue")
+                                        .paramCount(0)
+                                        .invoke();
+                            }
+
+                            if (imageView != null) {
+                                if (imageView.getContext().getClass().getName().contains("MultiForwardActivity")) {
+                                    imageView.setVisibility(View.GONE);
+                                    return;
+                                }
+                                imageView.setImageBitmap(RepeaterPlusIconSettingDialog.getRepeaterIcon());
+
+                                imageView.setOnClickListener(v -> {
+                                    if (RepeaterPlusIconSettingDialog.getIsDoubleClick()) {
+                                        try {
+                                            if (System.currentTimeMillis() - 200 > click_time) {
+                                                return;
+                                            }
+                                        } finally {
+                                            click_time = System.currentTimeMillis();
+                                        }
+                                    }
+
+                                    Object msgObj = param.args[1];
+                                    if (isMessageRepeatable(msgObj)) {
+                                        repeatByForwardNt(msgObj);
+                                    } else {
+                                        Toasts.error(v.getContext(), "该消息不支持复读");
+                                    }
+                                });
+
+                                imageView.setVisibility(0);
+                            }
+                        }
+                    }
+                };
+
+                Class<?> clz = Initiator.loadClass("com.tencent.mobileqq.aio.msglist.holder.component.msgfollow.AIOMsgFollowComponent");
+                for (Method method : clz.getDeclaredMethods()) {
+                    Class<?>[] pts = method.getParameterTypes();
+                    if (pts.length == 3 && pts[0].equals(int.class) && pts[2].equals(List.class)) {
+                        XposedBridge.hookMethod(method, callback);
+                    }
+                }
+            }
+            return true;
+        } else if (requireMinQQVersion(QQVersion.QQ_8_9_63_BETA_11345) || requireMinTimVersion(TIMVersion.TIM_4_0_95_BETA)) {
             if (!RepeaterPlusIconSettingDialog.getIsShowInMenu()) {
                 XC_MethodHook callback = new XC_MethodHook() {
                     private ImageView img;


### PR DESCRIPTION
# 标题 / Title Here

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description

<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR
修复RepeaterPlus在QQ 9.2.30+失效的问题
## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
