### PR TITLE
fix(ItemBuilderFactoryHook): prevent ClassCastException on older QQnt versions

### DIFF
--- a/app/src/main/java/io/github/qauxv/router/dispacher/ItemBuilderFactoryHook.kt
+++ b/app/src/main/java/io/github/qauxv/router/dispacher/ItemBuilderFactoryHook.kt
@@ -28,6 +28,7 @@ import io.github.qauxv.base.annotation.FunctionHookEntry
 import io.github.qauxv.hook.BaseHookDispatcher
 import io.github.qauxv.router.decorator.IItemBuilderFactoryHookDecorator
 import io.github.qauxv.util.Initiator
+import io.github.qauxv.util.Log
 import io.github.qauxv.util.dexkit.CItemBuilderFactory
 import io.github.qauxv.util.dexkit.DexKit
 import io.github.qauxv.util.dexkit.MsgListUtil_createMsgItem
@@ -56,14 +57,21 @@ object ItemBuilderFactoryHook : BaseHookDispatcher<IItemBuilderFactoryHookDecora
         SimpleReceiptMessage,
     )
 
+    private var msgRecordParamIndex = -1
+
     @Throws(Exception::class)
     override fun initOnce(): Boolean {
         if (QAppUtils.isQQnt()) {
             val createMsgItem = DexKit.requireMethodFromCache(MsgListUtil_createMsgItem)
+            msgRecordParamIndex = createMsgItem.parameterTypes.indexOfFirst { it == MsgRecord::class.java }
+            if (msgRecordParamIndex < 0) {
+                io.github.qauxv.util.Log.w("ItemBuilderFactoryHook: createMsgItem has no MsgRecord parameter, hook disabled")
+                return false
+            }
             XposedBridge.hookMethod(createMsgItem, object : XC_MethodHook(39) {
                 @Throws(Throwable::class)
                 override fun beforeHookedMethod(param: MethodHookParam) {
-                    val msgRecord = param.args[1] as MsgRecord
+                    val msgRecord = param.args[msgRecordParamIndex] as? MsgRecord ?: return
                     for (decorator in decorators) {
                         try {
                             if (decorator.isEnabled && decorator.onNtCreateItemHook(msgRecord, param)) {


### PR DESCRIPTION
# fix(ItemBuilderFactoryHook): resolve MsgRecord param index via reflection

## 描述 / Description

Since b3c9fad2, `ItemBuilderFactoryHook` hooks `MsgListUtil.createMsgItem` and hardcodes `param.args[1]` as `MsgRecord`. On older QQnt builds (e.g. QQ 9.1.25 / versionCode 8368), `args[1]` is a `Boolean`, causing a `ClassCastException` on every invocation.

This hook runs at **~412 invocations per second** (see comment in source). The unhandled exceptions generate massive garbage objects and stack trace strings, leading to:
- Steady Native Heap growth (~120 MB → 350 MB+ in minutes)
- ANR (main thread blocked on `WaitForGcToComplete`)
- Eventual OOM crash (`SIGABRT` with `OutOfMemoryError`)

**Fix (per maintainer feedback):** Instead of hardcoding the parameter index, reflect `createMsgItem.parameterTypes` at hook initialization time to find the `MsgRecord` parameter index, and cache it in a field for use in the callback:

```kotlin
private var msgRecordParamIndex = -1

override fun initOnce(): Boolean {
    if (QAppUtils.isQQnt()) {
        val createMsgItem = DexKit.requireMethodFromCache(MsgListUtil_createMsgItem)
        msgRecordParamIndex = createMsgItem.parameterTypes.indexOfFirst { it == MsgRecord::class.java }
        if (msgRecordParamIndex < 0) {
            Log.w("ItemBuilderFactoryHook: createMsgItem has no MsgRecord parameter, hook disabled")
            return false
        }
        XposedBridge.hookMethod(createMsgItem, object : XC_MethodHook(39) {
            override fun beforeHookedMethod(param: MethodHookParam) {
                val msgRecord = param.args[msgRecordParamIndex] as? MsgRecord ?: return
                // ...
            }
        })
        return true
    }
    // ...
}
```

No version number check is used. On all QQnt versions where `createMsgItem` has a `MsgRecord` parameter, the hook works correctly regardless of its position. If no `MsgRecord` parameter exists, the hook is disabled with a warning log.

## 修复或解决的问题 / Issues Fixed or Closed by This PR

Fixes OOM / ANR / crash on older QQnt versions (e.g. QQ 9.1.25) caused by `ClassCastException` flooding from `ItemBuilderFactoryHook` introduced in b3c9fad2.

## 检查列表 / Check List

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM.
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)

### Verification

| Metric | Before | After |
|--------|--------|-------|
| PSS | 672 MB → 1 GB+ (growing) | ~475 MB (stable) |
| Native Heap | 198 MB → 353 MB (growing) | ~125 MB (stable) |
| Exceptions/sec | ~412 `ClassCastException` | 0 |

Tested on QQ 9.1.25 (versionCode 8368), Pixel 9 Pro, Android 15 QPR3.