### PR TITLE
fix(AioChatPieClipPasteHook): fix clipboard image sending

### DIFF
--- a/app/src/main/java/cc/ioctl/hook/msg/AioChatPieClipPasteHook.java
+++ b/app/src/main/java/cc/ioctl/hook/msg/AioChatPieClipPasteHook.java
@@ -45,7 +45,10 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.inputmethod.EditorInfoCompat;
 import androidx.core.view.inputmethod.InputConnectionCompat;
+import cc.hicore.QApp.QAppUtils;
 import cc.hicore.message.bridge.Chat_facade_bridge;
+import cc.hicore.message.chat.SessionUtils;
+import cc.hicore.message.common.MsgSender;
 import cc.ioctl.util.SendCacheUtils;
 import cc.ioctl.util.ui.FaultyDialog;
 import io.github.duzhaokun123.activity.PictureEditProxyActivity;
@@ -58,6 +61,7 @@ import io.github.qauxv.base.annotation.FunctionHookEntry;
 import io.github.qauxv.base.annotation.UiItemAgentEntry;
 import io.github.qauxv.bridge.FaceImpl;
 import io.github.qauxv.bridge.SessionInfoImpl;
+import io.github.qauxv.bridge.kernelcompat.ContactCompat;
 import io.github.qauxv.databinding.DialogConfirmSendPictureBinding;
 import io.github.qauxv.dsl.FunctionEntryRouter;
 import io.github.qauxv.hook.CommonSwitchFunctionHook;
@@ -66,6 +70,7 @@ import io.github.qauxv.router.dispacher.InputButtonHookDispatcher;
 import io.github.qauxv.ui.CommonContextWrapper;
 import io.github.qauxv.util.Initiator;
 import io.github.qauxv.util.IoUtils;
+import io.github.qauxv.util.QQVersion;
 import io.github.qauxv.util.SyncUtils;
 import io.github.qauxv.util.dexkit.DexKitTarget;
 import io.github.qauxv.util.dexkit.NBaseChatPie_init;
@@ -80,6 +85,8 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import kotlin.Pair;
 import mqq.app.AppRuntime;
+
+import static cc.ioctl.util.HostInfo.requireMinQQVersion;
 
 @FunctionHookEntry
 @UiItemAgentEntry
@@ -322,7 +329,12 @@ public class AioChatPieClipPasteHook extends CommonSwitchFunctionHook implements
             @NonNull ViewGroup aioRootView, @NonNull AppRuntime rt) {
         try {
             File file = SendCacheUtils.saveAsCacheFile(context, data);
-            Chat_facade_bridge.sendPic(session, file);
+            if (QAppUtils.isQQnt() && requireMinQQVersion(QQVersion.QQ_9_2_30)) {
+                ContactCompat contact = SessionUtils.AIOParam2Contact(InputButtonHookDispatcher.AIOParam);
+                MsgSender.send_pic_by_contact(contact, file.getAbsolutePath());
+            } else {
+                Chat_facade_bridge.sendPic(session, file);
+            }
         } catch (IOException e) {
             FaultyDialog.show(context, e);
         }


### PR DESCRIPTION
# 标题 / Title Here

修复剪切板粘贴图片

## 描述 / Description

`QQ 9.2.30`之后的版本剪切板粘贴图片后不会有任何图片发出

功能截图如下

<img width="359" height="276" alt="image" src="https://github.com/user-attachments/assets/39c22213-7058-4374-9fee-1f78518d65a0" />


## 修复或解决的问题 / Issues Fixed or Closed by This PR

本 PR 复用了 MsgSender 中现有的机制来调用 QQNT 的图片发送功能，从而为剪贴板图片发送提供支持
https://github.com/cinit/QAuxiliary/blob/805cb4f7e37b801e749421794b62ef1e2034c7c2/app/src/main/java/cc/hicore/message/common/MsgSender.java#L32-L47

MsgSender 方法已测试可以在`QQ 9.2.27` `QQ 9.2.30` `QQ 9.2.90` `QQ 9.3.35`版本下为`AioChatPieClipPasteHook`正常发送图片

受限于测试环境（如 QQ 9.0.x 目前我已无法登录），为确保稳定性，新逻辑仅对 `QQ 9.2.30` 及以上版本生效。低于此版本的 QQNT 将回退并沿用原有代码逻辑。已测试原有代码逻辑最后生效的版本为 `QQ 9.2.27`，因此较低版本的QQNT应该不会丢失该功能。

由于暂无相关测试环境，无法完全排除 AIOParam2Contact 方法在非 QQNT 版本及 TIM 中引发异常的风险。出于安全考虑，非 QQNT 版本及 TIM 同样保持原有逻辑不变。

编译后已在`QQ 9.2.27` `QQ 9.2.30` `QQ 9.2.90` `QQ 9.3.35`版本下测试过

<img width="320" height="704" alt="Screenshot_2026-08-22-17-07-47-59_9d26c6446fd7bb8e41d99b6262b17def" src="https://github.com/user-attachments/assets/fe132941-ce75-4fcb-93f2-336bf5d912cf" />

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
