### PR TITLE
fix: MultiActionHook on tim 3.5.6 ~ 3.5.8

### DIFF
--- a/app/src/main/java/io/github/qauxv/tlb/TIMConfigTable.kt
+++ b/app/src/main/java/io/github/qauxv/tlb/TIMConfigTable.kt
@@ -46,6 +46,7 @@ class TIMConfigTable : ConfigTableInterface {
             TIM_3_1_1 to "PK",
             TIM_3_3_0 to "PO",
             TIM_3_5_0 to "PB",
+            TIM_3_5_6 to "b",
         ),
 
         ReplyNoAtHook::class.java.simpleName to mapOf(


### PR DESCRIPTION
# 标题 / Title Here

MultiActionHook on tim 3.5.6 ~ 3.5.8

<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## 描述 / Description

修复 TIM 3.5.6 ~ 3.5.8 中 批量撤回 无法使用

原始错误信息:

````
java.lang.NoSuchMethodException: PB(boolean) in anco
 at cc.ioctl.util.Reflex.invokeVirtual(Reflex.java:736)
 at io.github.qauxv.bridge.QQMessageFacade.revokeMessage(QQMessageFacade.java:87)
 at me.ketal.hook.MultiActionHook.recall$lambda$0(MultiActionHook.kt:208)
 at me.ketal.hook.MultiActionHook$$ExternalSyntheticLambda9.invoke(D8$$SyntheticClass:0)
 at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)
````
<!--- Describe your changes in detail here. -->

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 检查列表 / Check List

<!--- 请根据您的实际情况勾选下面的复选框，并非全部都需要勾选。 -->
<!--- Please check the checkboxes below according to your ACTUAL situation. This is NOT a must-check-all list. -->

- [x] 我已经在预期的 QQ 或 TIM 版本上测试了这些更改，并确认它们能够正常工作，不会破坏任何东西（尽我所能）。
  I have tested these changes on the expected version and confirmed that they work and don't break anything (as well as I can manage).
- [x] 我的改动不会导致本模块丢失对旧版 QQ 或 TIM 的支持。
  My changes will not cause this module to lose support for older versions of QQ or TIM。
- [x] 我已经合并了对后续工作无意义的提交，并确认它们不会对后续维护造成破坏。（必须）
  I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance. (Required)
